### PR TITLE
Add phase banner component for collecting feedback

### DIFF
--- a/gov_uk_dashboards/components/plotly/phase_banner.py
+++ b/gov_uk_dashboards/components/plotly/phase_banner.py
@@ -1,0 +1,39 @@
+"""phase_banner"""
+from dash import html
+
+
+def phase_banner_with_feedback(
+    phase: str, feedback_link: str, link_id: str = "feedback-link"
+):
+    """Creates a phase banner with a feedback link, which can be specified.
+    The id of the 'feedback' link can be set to allow for targeting with callbacks.
+
+    The phase banner is set out here as part of the Gov.UK design system:
+    https://design-system.service.gov.uk/components/phase-banner/"""
+    return html.Div(
+        [
+            html.P(
+                [
+                    html.Strong(
+                        [phase],
+                        className="govuk-tag govuk-phase-banner__content__tag",
+                    ),
+                    html.Span(
+                        [
+                            "This is a new service - your ",
+                            html.A(
+                                ["feedback"],
+                                href=feedback_link,
+                                className="govuk-link",
+                                id=link_id,
+                            ),
+                            " will help us to improve it.",
+                        ],
+                        className="govuk-phase-banner__text",
+                    ),
+                ],
+                className="govuk-phase-banner__content",
+            )
+        ],
+        className="govuk-phase-banner",
+    )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.4.0",
+    version="2.5.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/97545171/156812164-bcc376a8-b032-451c-a76b-1c7f67d8b857.png)
Added a **phase banner component**, matching the Gov.UK Design System component here: https://design-system.service.gov.uk/components/phase-banner/

This is intended to be used to collect feedback from users while our dashboards are being developed.

It allows you to set the phase (e.g. alpha, beta) and set a link to collect feedback, which can be mailto: link to create a template e-mail. Also included a settable id for the link so the link address can be targeted by callbacks, which will allow the subject of the e-mail generated to be set according to which dashboard page the user is currently on (along with potentially other things if we wanted).