### PR TITLE
Added details and footer components

### DIFF
--- a/gov_uk_dashboards/components/plotly/details.py
+++ b/gov_uk_dashboards/components/plotly/details.py
@@ -1,0 +1,36 @@
+"""details"""
+from dash import html
+
+
+def details(details_summary: str, details_text:str) -> html.Details:
+    """
+    HTML component for showing a summary exapandable with more information beneath.
+
+    Makes a page easier to scan by letting users reveal more detailed information
+    only if they need it.
+
+    Part of the Gov.UK Design System:
+    https://design-system.service.gov.uk/components/details/
+
+    Args:
+        details_summary (str): The summary text to display all the time.
+        details_text (str): The details to reveal when the use requests them.
+    
+    Returns:
+        html.Details: A Details HTML element with the specified text
+    """
+    return html.Details(
+        [
+            html.Summary(
+                [
+                    html.Span(
+                        details_summary,
+                        className="govuk-details__summary-text",
+                    )
+                ],
+                className="govuk-details__summary",
+            ),
+            html.Div(details_text, className="govuk-details__text"),
+        ],
+        className="govuk-details",
+    )

--- a/gov_uk_dashboards/components/plotly/details.py
+++ b/gov_uk_dashboards/components/plotly/details.py
@@ -2,7 +2,7 @@
 from dash import html
 
 
-def details(details_summary: str, details_text:str) -> html.Details:
+def details(details_summary: str, details_text: str) -> html.Details:
     """
     HTML component for showing a summary exapandable with more information beneath.
 
@@ -15,7 +15,7 @@ def details(details_summary: str, details_text:str) -> html.Details:
     Args:
         details_summary (str): The summary text to display all the time.
         details_text (str): The details to reveal when the use requests them.
-    
+
     Returns:
         html.Details: A Details HTML element with the specified text
     """

--- a/gov_uk_dashboards/components/plotly/footer.py
+++ b/gov_uk_dashboards/components/plotly/footer.py
@@ -1,0 +1,56 @@
+"""footer"""
+from dash import html
+
+
+def footer():
+    """
+    HTML component for a Gov.UK standard footer.
+
+    The footer provides copyright, licensing and other information about your
+    service and department.
+
+    Part of the Gov.UK Design System:
+    https://design-system.service.gov.uk/components/footer/
+    
+    Returns:
+        html.Footer: A footer element with copyright information.
+    """
+    return html.Footer(
+        html.Div(
+            html.Div(
+                [
+                    html.Div(
+                        html.Span(
+                            [
+                                "All content is available under the",
+                                html.A(
+                                    "Open Government Licence v3.0",
+                                    rel="license",
+                                    href="https://www.nationalarchives.gov.uk/doc/"
+                                    "open-government-licence/version/3/",
+                                    className="govuk-footer__link",
+                                ),
+                                ", except where otherwise stated",
+                            ],
+                            className="govuk-footer__licence-description",
+                        ),
+                        className="govuk-footer__meta-item govuk-footer__meta-item--grow",
+                    ),
+                    html.Div(
+                        html.A(
+                            "© Crown copyright",
+                            className="govuk-footer__link govuk-footer__copyright-logo",
+                            href="https://www.nationalarchives.gov.uk/information-management/"
+                            "re-using-public-sector-information/uk-government-licensing-framework/"
+                            "crown-copyright/",
+                        ),
+                        className="govuk-footer__meta-item",
+                    ),
+                ],
+                className="govuk-footer__meta",
+            ),
+            className="govuk-width-container",
+        ),
+        className="govuk-footer",
+        role="contentinfo",
+    )

--- a/gov_uk_dashboards/components/plotly/footer.py
+++ b/gov_uk_dashboards/components/plotly/footer.py
@@ -22,7 +22,7 @@ def footer():
                     html.Div(
                         html.Span(
                             [
-                                "All content is available under the",
+                                "All content is available under the ",
                                 html.A(
                                     "Open Government Licence v3.0",
                                     rel="license",

--- a/gov_uk_dashboards/components/plotly/footer.py
+++ b/gov_uk_dashboards/components/plotly/footer.py
@@ -11,7 +11,7 @@ def footer():
 
     Part of the Gov.UK Design System:
     https://design-system.service.gov.uk/components/footer/
-    
+
     Returns:
         html.Footer: A footer element with copyright information.
     """

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.7.0",
+    version="2.8.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
Added two components we created as part of LearnTech Friday:
![image](https://user-images.githubusercontent.com/97545171/159053044-666493a4-880a-4a5b-8eb8-179704d52295.png)
A 'details' component, potentially useful for providing explanatory information regarding some of our technical terms.
![image](https://user-images.githubusercontent.com/97545171/159053187-dd429f51-b940-43f4-9a88-037cbcaad431.png)
A footer in the Gov.UK style.