### PR TITLE
Added table component for displaying dataframes

### DIFF
--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -1,0 +1,72 @@
+"""Function for creating a table component from a dataframe"""
+from pandas import DataFrame
+from dash import html
+
+
+def table_from_dataframe(
+    dataframe: DataFrame,
+    title: str = None,
+    include_headers: bool = True,
+    first_column_is_header: bool = True,
+    **table_properties
+):
+    """
+    Displays a pandas DataFrame as a table formatted in the Gov.UK style
+
+    Part of the Gov.UK Design System:
+    https://design-system.service.gov.uk/components/table/
+
+
+    Args:
+        df (DataFrame): Dataframe containing formatted data to display.
+        title (str, optional): Title to display above the table. Defaults to None.
+        include_headers (bool, optional): If the column labels should be included as headers.
+            Defaults to True.
+        first_column_is_header (bool, optional): _description_. Defaults to True.
+        **table_properties: Any additional arguments for the html.Table object,
+            such as setting a width or id.
+
+    Returns:
+        html.Table: The dash HTML object for the table.
+    """
+    table_contents = []
+
+    if title:
+        table_contents.append(
+            html.Caption(
+                title, className="govuk-table__caption govuk-table__caption--m"
+            )
+        )
+
+    if include_headers:
+        table_contents.append(
+            html.Thead(
+                html.Tr(
+                    [
+                        html.Th(header, scope="col", className="govuk-table__header")
+                        for header in dataframe.columns
+                    ],
+                    className="govuk-table__row",
+                ),
+                className="govuk-table__head",
+            )
+        )
+
+    table_contents.append(
+        html.Tbody(
+            [
+                html.Tr(
+                    [html.Th(row[0], scope="row", className="govuk-table__header")]
+                    + [html.Td(cell, className="govuk-table__cell") for cell in row[1:]]
+                )
+                if first_column_is_header
+                else html.Tr(
+                    [html.Td(cell, className="govuk-table__cell") for cell in row]
+                )
+                for _, row in dataframe.iterrows()
+            ],
+            className="govuk-table__body",
+        )
+    )
+
+    return html.Table(table_contents, className="govuk-table", **table_properties)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.8.0",
+    version="2.9.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/97545171/159253631-a5e1cecf-7323-4017-83da-a8f6279e34d8.png)
Added component to display pandas DataFrames as HTML tables in the [Gov.UK Design System style](https://design-system.service.gov.uk/components/table/).

Includes options to include a title, whether the first column is treated as a header column, and whether to include the column labels as headers.

I intend to make use of this in [this ticket](https://trello.com/c/flKZLMX0).