### PR TITLE
Add human readable formatting function to pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ from gov_uk_dashboards.components.plotly import banners
 banners.message_banner('category','message')
 ```
 
+For formatting:
+```python
+from gov_uk_dashboards.formatting.human_readable import format_as_human_readable
+
+format_as_human_readable(1200,prefix='£')
+```
+
 ## Updating
 
 When making changes to the package, the following should be done:

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - dash=2.0
   - pytest=6.2
   - pylint=2.12
-  - black=21.12b0
+  - black=22.3.0
   - numpy=1.22.0
   - pandas=1.3
   - dash-bootstrap-components=1.0.3

--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -1,7 +1,7 @@
 """Functions for converting values to human readable format"""
 
 
-def format_as_human_readable(value_to_format: float, /, *, prefix: str = "") -> str:
+def format_as_human_readable(value_to_format: float, *, prefix: str = "") -> str:
     """Format a number as a human readable string
     Appends bn, m, k as appropriate
     Rounds number to 3dp
@@ -20,4 +20,4 @@ def format_as_human_readable(value_to_format: float, /, *, prefix: str = "") -> 
         return f"{prefix}{value_to_format/1_000_000:g}m"
     if value_to_format >= 1_000:
         return f"{prefix}{value_to_format/1_000:g}k"
-    return f"{prefix}{value_to_format:,g}"
+    return f"{prefix}{value_to_format:g}"

--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -1,0 +1,23 @@
+"""Functions for converting values to human readable format"""
+
+
+def format_as_human_readable(value_to_format: float, /, *, prefix: str = "") -> str:
+    """Format a number as a human readable string
+    Appends bn, m, k as appropriate
+    Rounds number to 3dp
+
+    Args:
+        value_to_format(float): number to format
+        prefix(str,optional): prefix to append to the start
+
+    Returns:
+        str: formatted number
+    """
+
+    if value_to_format >= 1_000_000_000:
+        return f"{prefix}{value_to_format/1_000_000_000:g}bn"
+    if value_to_format >= 1_000_000:
+        return f"{prefix}{value_to_format/1_000_000:g}m"
+    if value_to_format >= 1_000:
+        return f"{prefix}{value_to_format/1_000:g}k"
+    return f"{prefix}{value_to_format:,g}"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.9.0",
+    version="2.10.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
@@ -4,22 +4,22 @@ from gov_uk_dashboards.formatting.human_readable import format_as_human_readable
 def test_format_as_human_readable_returns_formatted_billions():
     assert format_as_human_readable(1_000_000_000) == "1bn"
     assert format_as_human_readable(2_100_000_000) == "2.1bn"
-    assert format_as_human_readable(45_678_987_654, "£") == "£45.679bn"
+    assert format_as_human_readable(45_678_987_654, prefix = "£") == "£45.679bn"
 
 
 def test_format_as_human_readable_returns_formatted_millions():
     assert format_as_human_readable(1_000_000) == "1m"
     assert format_as_human_readable(999_100_000) == "999.1m"
-    assert format_as_human_readable(45_678_987, "$") == "$45.679m"
+    assert format_as_human_readable(45_678_987, prefix = "$") == "$45.679m"
 
 
 def test_format_as_human_readable_returns_formatted_thousands():
     assert format_as_human_readable(1_000) == "1k"
     assert format_as_human_readable(425_000) == "425k"
-    assert format_as_human_readable(45_678, "ABC") == "ABC45.678k"
+    assert format_as_human_readable(45_678, prefix = "ABC") == "ABC45.678k"
 
 
 def test_format_as_human_readable_returns_formatted_units():
     assert format_as_human_readable(1) == "1"
     assert format_as_human_readable(999) == "999"
-    assert format_as_human_readable(45.678, "ABC") == "ABC45.678"
+    assert format_as_human_readable(45.678, prefix = "ABC") == "ABC45.678"

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
@@ -4,22 +4,22 @@ from gov_uk_dashboards.formatting.human_readable import format_as_human_readable
 def test_format_as_human_readable_returns_formatted_billions():
     assert format_as_human_readable(1_000_000_000) == "1bn"
     assert format_as_human_readable(2_100_000_000) == "2.1bn"
-    assert format_as_human_readable(45_678_987_654, prefix = "£") == "£45.679bn"
+    assert format_as_human_readable(45_678_987_654, prefix="£") == "£45.679bn"
 
 
 def test_format_as_human_readable_returns_formatted_millions():
     assert format_as_human_readable(1_000_000) == "1m"
     assert format_as_human_readable(999_100_000) == "999.1m"
-    assert format_as_human_readable(45_678_987, prefix = "$") == "$45.679m"
+    assert format_as_human_readable(45_678_987, prefix="$") == "$45.679m"
 
 
 def test_format_as_human_readable_returns_formatted_thousands():
     assert format_as_human_readable(1_000) == "1k"
     assert format_as_human_readable(425_000) == "425k"
-    assert format_as_human_readable(45_678, prefix = "ABC") == "ABC45.678k"
+    assert format_as_human_readable(45_678, prefix="ABC") == "ABC45.678k"
 
 
 def test_format_as_human_readable_returns_formatted_units():
     assert format_as_human_readable(1) == "1"
     assert format_as_human_readable(999) == "999"
-    assert format_as_human_readable(45.678, prefix = "ABC") == "ABC45.678"
+    assert format_as_human_readable(45.678, prefix="ABC") == "ABC45.678"

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
@@ -1,0 +1,25 @@
+from gov_uk_dashboards.formatting.human_readable import format_as_human_readable
+
+
+def test_format_as_human_readable_returns_formatted_billions():
+    assert format_as_human_readable(1_000_000_000) == "1bn"
+    assert format_as_human_readable(2_100_000_000) == "2.1bn"
+    assert format_as_human_readable(45_678_987_654, "£") == "£45.679bn"
+
+
+def test_format_as_human_readable_returns_formatted_millions():
+    assert format_as_human_readable(1_000_000) == "1m"
+    assert format_as_human_readable(999_100_000) == "999.1m"
+    assert format_as_human_readable(45_678_987, "$") == "$45.679m"
+
+
+def test_format_as_human_readable_returns_formatted_thousands():
+    assert format_as_human_readable(1_000) == "1k"
+    assert format_as_human_readable(425_000) == "425k"
+    assert format_as_human_readable(45_678, "ABC") == "ABC45.678k"
+
+
+def test_format_as_human_readable_returns_formatted_units():
+    assert format_as_human_readable(1) == "1"
+    assert format_as_human_readable(999) == "999"
+    assert format_as_human_readable(45.678, "ABC") == "ABC45.678"


### PR DESCRIPTION
Adds a function to turn values into human readable versions.

E.g.
1,200,000,000 -> 1.2bn
252,000 -> 252k

Can add a prefix as well for convenience, such as '£'