### PR TITLE
Add rounding functionality to formatting

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3.9
   - dash=2.0
+  - Werkzeug=2.0.3
   - pytest=6.2
   - pylint=2.12
   - black=22.3.0

--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -40,7 +40,7 @@ def format_as_human_readable(
         value = value_to_format / 1_000
         value_suffix = "k"
 
-    if decimal_places:
+    if decimal_places is not None:
         value = round(value, decimal_places)
 
     return f"{prefix}{value:g}{value_suffix}{suffix}"

--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -1,23 +1,46 @@
 """Functions for converting values to human readable format"""
 
 
-def format_as_human_readable(value_to_format: float, *, prefix: str = "") -> str:
-    """Format a number as a human readable string
-    Appends bn, m, k as appropriate
-    Rounds number to 3dp
+from typing import Optional
+
+
+def format_as_human_readable(
+    value_to_format: float,
+    *,
+    prefix: str = "",
+    suffix: str = "",
+    decimal_places: Optional[int] = None,
+) -> str:
+    """
+    Format a number as a human readable string.
+    Appends bn, m, k as appropriate.
+    E.g. 1,200,000 -> 1.2m
 
     Args:
         value_to_format(float): number to format
-        prefix(str,optional): prefix to append to the start
+        prefix(str,optional): prefix to append to the start (e.g. £). Defaults to no prefix.
+        suffix(str,optional): suffix to append to the end (e.g. %). Defaults to no suffix.
+        decimal_places(int, optional): If set, rounds formatted number to that many d.p.
+            This is applied after shortening, e.g. 1,234,000 with decimal places = 1 becomes
+            1.2m. Defaults to None, which does not apply rounding.
 
     Returns:
         str: formatted number
     """
+    value_suffix = ""
+    value = value_to_format
 
     if value_to_format >= 1_000_000_000:
-        return f"{prefix}{value_to_format/1_000_000_000:g}bn"
-    if value_to_format >= 1_000_000:
-        return f"{prefix}{value_to_format/1_000_000:g}m"
-    if value_to_format >= 1_000:
-        return f"{prefix}{value_to_format/1_000:g}k"
-    return f"{prefix}{value_to_format:g}"
+        value = value_to_format / 1_000_000_000
+        value_suffix = "bn"
+    elif value_to_format >= 1_000_000:
+        value = value_to_format / 1_000_000
+        value_suffix = "m"
+    elif value_to_format >= 1_000:
+        value = value_to_format / 1_000
+        value_suffix = "k"
+
+    if decimal_places:
+        value = round(value, decimal_places)
+
+    return f"{prefix}{value:g}{value_suffix}{suffix}"

--- a/gov_uk_dashboards/formatting/rounding.py
+++ b/gov_uk_dashboards/formatting/rounding.py
@@ -1,0 +1,29 @@
+"""Functions to round data to the standard rounding we want for display"""
+
+
+def round_thousands_to_1dp(value: float) -> float:
+    """
+    Rounds values to 1dp in steps of 1000.
+    Rounds values greater than 1B to nearest 100M
+    Rounds values > 1B and >= 1M to nearest 100k
+    Rounds values > 1M and >= 1k to nearest 100
+    Rounds values less than 1000 to 1dp.
+    If value is not a number, return original value.
+
+    Args:
+        value (float): Value to round
+
+    Returns:
+        float: Rounded value
+    """
+    try:
+        if value >= 1_000_000_000:
+            return round(value, -8)
+        if value >= 1_000_000:
+            return round(value, -5)
+        if value >= 1000:
+            return round(value, -2)
+        return round(value, 1)
+
+    except TypeError:
+        return value

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.11.1",
+    version="2.12.1",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.12.1",
+    version="2.12.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
@@ -1,4 +1,5 @@
-from gov_uk_dashboards.formatting.human_readable import format_as_human_readable
+from gov_uk_dashboards.formatting.human_readable import \
+    format_as_human_readable
 
 
 def test_format_as_human_readable_returns_formatted_billions():
@@ -23,3 +24,22 @@ def test_format_as_human_readable_returns_formatted_units():
     assert format_as_human_readable(1) == "1"
     assert format_as_human_readable(999) == "999"
     assert format_as_human_readable(45.678, prefix="ABC") == "ABC45.678"
+
+
+def test_format_as_human_readable_returns_adds_suffix():
+    assert format_as_human_readable(1, suffix="%") == "1%"
+    assert (
+        format_as_human_readable(156_000, prefix="£", suffix=" per annum")
+        == "£156k per annum"
+    )
+
+
+def test_format_as_human_readable_applies_rounding():
+    assert format_as_human_readable(1.234, decimal_places=1) == "1.2"
+    assert format_as_human_readable(1_234_567, decimal_places=2) == "1.23m"
+    assert format_as_human_readable(12_345, prefix="£", decimal_places=0) == "£12k"
+
+def test_format_as_human_readable_applies_negative_round():
+    assert format_as_human_readable(123, decimal_places=-1) == "120"
+    assert format_as_human_readable(567_890, decimal_places=-1) == "570k"
+    assert format_as_human_readable(567_890, decimal_places=-2) == "600k"

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
@@ -1,5 +1,4 @@
-from gov_uk_dashboards.formatting.human_readable import \
-    format_as_human_readable
+from gov_uk_dashboards.formatting.human_readable import format_as_human_readable
 
 
 def test_format_as_human_readable_returns_formatted_billions():
@@ -38,6 +37,7 @@ def test_format_as_human_readable_applies_rounding():
     assert format_as_human_readable(1.234, decimal_places=1) == "1.2"
     assert format_as_human_readable(1_234_567, decimal_places=2) == "1.23m"
     assert format_as_human_readable(12_345, prefix="£", decimal_places=0) == "£12k"
+
 
 def test_format_as_human_readable_applies_negative_round():
     assert format_as_human_readable(123, decimal_places=-1) == "120"

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_round_thousands_to_1dp.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_round_thousands_to_1dp.py
@@ -1,0 +1,21 @@
+from gov_uk_dashboards.formatting.rounding import round_thousands_to_1dp
+
+
+def test_round_thousands_to_1dp_returns_rounded_billions():
+    assert round_thousands_to_1dp(1_234_567_890) == 1_200_000_000
+    assert round_thousands_to_1dp(45_678_987_654) == 45_700_000_000
+
+
+def test_round_thousands_to_1dp_returns_rounded_millions():
+    assert round_thousands_to_1dp(1_234_567) == 1_200_000
+    assert round_thousands_to_1dp(45_678_987) == 45_700_000
+
+
+def test_round_thousands_to_1dp_returns_rounded_thousands():
+    assert round_thousands_to_1dp(1_234) == 1_200
+    assert round_thousands_to_1dp(45_678) == 45_700
+
+
+def test_round_thousands_to_1dp_returns_rounded_units():
+    assert round_thousands_to_1dp(1.234) == 1.2
+    assert round_thousands_to_1dp(45.678) == 45.7


### PR DESCRIPTION
Added commonly used rounding functionality to the formatting in the package.

- round_thousands_to_1dp has been added, to round figures to 1dp in steps of a thousand. This previously has been in our Local Government Dashboard, but seemed sensible to add here as generally useful functionality
- format_as_human_readable now has two new optional arguments, decimal_places (which sets the decimal places to round to) and suffix (for adding stuff like '%' or 'per annum' after the number).

Also added tests for the new function/functionality