### PR TITLE
Add argument to table to allow sizing the title

### DIFF
--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -7,7 +7,6 @@ from dash import html
 def table_from_dataframe(
     dataframe: DataFrame,
     title: Optional[str] = None,
-    *,
     include_headers: bool = True,
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -1,11 +1,12 @@
 """Function for creating a table component from a dataframe"""
+from typing import Optional
 from pandas import DataFrame
 from dash import html
 
 
 def table_from_dataframe(
     dataframe: DataFrame,
-    title: str = None,
+    title: Optional[str] = None,
     *,
     include_headers: bool = True,
     first_column_is_header: bool = True,

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -6,8 +6,10 @@ from dash import html
 def table_from_dataframe(
     dataframe: DataFrame,
     title: str = None,
+    *,
     include_headers: bool = True,
     first_column_is_header: bool = True,
+    title_is_subtitle: bool = False,
     **table_properties
 ):
     """
@@ -22,7 +24,10 @@ def table_from_dataframe(
         title (str, optional): Title to display above the table. Defaults to None.
         include_headers (bool, optional): If the column labels should be included as headers.
             Defaults to True.
-        first_column_is_header (bool, optional): _description_. Defaults to True.
+        first_column_is_header (bool, optional): Sets if the first column is a header column.
+            Defaults to True.
+        title_is_subtitle (bool, optional): Sets if the title should be displayed as a subtitle
+            or full title. Defaults to False.
         **table_properties: Any additional arguments for the html.Table object,
             such as setting a width or id.
 
@@ -34,7 +39,10 @@ def table_from_dataframe(
     if title:
         table_contents.append(
             html.Caption(
-                title, className="govuk-table__caption govuk-table__caption--m"
+                title,
+                className="govuk-table__caption govuk-table__caption--s"
+                if title_is_subtitle
+                else "govuk-table__caption govuk-table__caption--m",
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.13.0",
+    version="2.14.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
Added an optional argument to table_from_dataframe allowing for a smaller title where desired. Doesn't break backward compatibility.