### PR TITLE
return "-" from human_readable when called with None or NaN

### DIFF
--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -23,7 +23,8 @@ def format_as_human_readable(
         decimal_places(int, optional): If set, rounds formatted number to that many d.p.
             This is applied after shortening, e.g. 1,234,000 with decimal places = 1 becomes
             1.2m. Defaults to None, which does not apply rounding.
-        separator(str,optional): If set, will be returned for a NaN or None passed as value_to_format
+        separator(str,optional): If set, will be returned for a NaN or None passed as
+            value_to_format
 
     Returns:
         str: formatted number

--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -9,7 +9,7 @@ def format_as_human_readable(
     prefix: str = "",
     suffix: str = "",
     decimal_places: Optional[int] = None,
-    separator = "-"
+    separator="-",
 ) -> str:
     """
     Format a number as a human readable string.

--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -1,6 +1,5 @@
 """Functions for converting values to human readable format"""
-
-
+import math
 from typing import Optional
 
 
@@ -10,6 +9,7 @@ def format_as_human_readable(
     prefix: str = "",
     suffix: str = "",
     decimal_places: Optional[int] = None,
+    separator = "-"
 ) -> str:
     """
     Format a number as a human readable string.
@@ -23,12 +23,16 @@ def format_as_human_readable(
         decimal_places(int, optional): If set, rounds formatted number to that many d.p.
             This is applied after shortening, e.g. 1,234,000 with decimal places = 1 becomes
             1.2m. Defaults to None, which does not apply rounding.
+        separator(str,optional): If set, will be returned for a NaN or None passed as value_to_format
 
     Returns:
         str: formatted number
     """
     value_suffix = ""
     value = value_to_format
+
+    if value_to_format is None or math.isnan(value_to_format):
+        return separator
 
     if value_to_format >= 1_000_000_000:
         value = value_to_format / 1_000_000_000

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
@@ -47,4 +47,7 @@ def test_format_as_human_readable_applies_negative_round():
 
 def test_format_as_human_readable_returns_dash_for_nan():
     assert format_as_human_readable(None, decimal_places=-1) == "-"
-    assert format_as_human_readable(float("NaN"), decimal_places=-1, separator="ABC") == "ABC"
+    assert (
+        format_as_human_readable(float("NaN"), decimal_places=-1, separator="ABC")
+        == "ABC"
+    )

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_format_as_human_readable.py
@@ -43,3 +43,8 @@ def test_format_as_human_readable_applies_negative_round():
     assert format_as_human_readable(123, decimal_places=-1) == "120"
     assert format_as_human_readable(567_890, decimal_places=-1) == "570k"
     assert format_as_human_readable(567_890, decimal_places=-2) == "600k"
+
+
+def test_format_as_human_readable_returns_dash_for_nan():
+    assert format_as_human_readable(None, decimal_places=-1) == "-"
+    assert format_as_human_readable(float("NaN"), decimal_places=-1, separator="ABC") == "ABC"


### PR DESCRIPTION
If format_as_human_readable is called with None or Nan then return a separator of "-". The separator can be overridden with a user desired value