### PR TITLE
Fix ONS Accessible Colour - light blue

### DIFF
--- a/gov_uk_dashboards/colours.py
+++ b/gov_uk_dashboards/colours.py
@@ -47,4 +47,4 @@ class ONSAccessibleColours(Enum):
     DARK_BLUE = "#206095"
     LIME = "#a8bd3a"
     MAROON = "#871a5b"
-    LIGHT_BLUE = "#871a5b"
+    LIGHT_BLUE = "#27a0cc"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="2.14.0",
+    version="2.15.1",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
While working on another ticket, we found that the light blue on the ONS Accessible Colours had been set up incorrectly (was just a duplicate of maroon). This sets it to the intended colour.

Also, looks like setup.py wasn't updated last time, so that is also set to the right version number.