### PR TITLE
Added a new paragraph component

### DIFF
--- a/gov_uk_dashboards/components/plotly/paragraph.py
+++ b/gov_uk_dashboards/components/plotly/paragraph.py
@@ -12,7 +12,7 @@ class ParagraphSizes(str, Enum):
 
 
 def paragraph(text: str, size: ParagraphSizes = ParagraphSizes.DEFAULT) -> html.P:
-    """Create a <p> Html component with the test provided"""
+    """Create a <p> Html component with the text provided"""
     if size not in list(ParagraphSizes):
         raise ValueError(
             f"Size {size} is not a valid paragraph size (use ParagraphSize enum)."

--- a/gov_uk_dashboards/components/plotly/paragraph.py
+++ b/gov_uk_dashboards/components/plotly/paragraph.py
@@ -1,14 +1,17 @@
+"""paragraph component"""
 from enum import Enum
 from dash import html
 
 
 class ParagraphSizes(str, Enum):
+    """Enum class to specify the allowed paragraph sizes"""
     LEAD = "govuk-body-l"
     DEFAULT = "govuk-body"
     SMALL = "govuk-body-s"
 
 
 def paragraph(text: str, size: ParagraphSizes = ParagraphSizes.DEFAULT) -> html.P:
+    """Create a <p> Html component with the test provided"""
     if size not in list(ParagraphSizes):
         raise ValueError(
             f"Size {size} is not a valid paragraph size (use ParagraphSize enum)."

--- a/gov_uk_dashboards/components/plotly/paragraph.py
+++ b/gov_uk_dashboards/components/plotly/paragraph.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from dash import html
+
+
+class ParagraphSizes(str, Enum):
+    LEAD = "govuk-body-l"
+    DEFAULT = "govuk-body"
+    SMALL = "govuk-body-s"
+
+
+def paragraph(text: str, size: ParagraphSizes = ParagraphSizes.DEFAULT) -> html.P:
+    if size not in list(ParagraphSizes):
+        raise ValueError(
+            f"Size {size} is not a valid paragraph size (use ParagraphSize enum)."
+        )
+
+    return html.P(
+        text,
+        className=size,
+    )

--- a/gov_uk_dashboards/components/plotly/paragraph.py
+++ b/gov_uk_dashboards/components/plotly/paragraph.py
@@ -5,6 +5,7 @@ from dash import html
 
 class ParagraphSizes(str, Enum):
     """Enum class to specify the allowed paragraph sizes"""
+
     LEAD = "govuk-body-l"
     DEFAULT = "govuk-body"
     SMALL = "govuk-body-s"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.0.0",
+    version="4.1.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",

--- a/tests/unit_tests/gov_uk_dashboards/components/plotly/test_paragraph.py
+++ b/tests/unit_tests/gov_uk_dashboards/components/plotly/test_paragraph.py
@@ -1,0 +1,64 @@
+"""Tests for paragraph component"""
+import pytest
+from dash import html
+
+from gov_uk_dashboards.components.plotly.paragraph import ParagraphSizes, paragraph
+
+
+def test_paragraph_returns_html_p():
+    """Test component returns a dash <P>"""
+    actual = paragraph("")
+
+    assert isinstance(actual, html.P)
+
+
+def test_paragraph_has_text_in_children():
+    """Test component has supplied text as its children"""
+    test_text = "A sentence"
+
+    actual = paragraph(test_text)
+
+    assert actual.children == test_text
+
+
+def test_paragraph_default_class():
+    """Test component has correct CSS class under default"""
+    test_text = "A sentence"
+
+    actual = paragraph(test_text)
+
+    assert getattr(actual, "className") == "govuk-body"
+
+
+def test_paragraph_lead_class():
+    """Test component has correct class when lead size is specified"""
+    test_text = "A sentence"
+
+    actual = paragraph(test_text, ParagraphSizes.LEAD)
+
+    assert getattr(actual, "className") == "govuk-body-l"
+
+
+def test_paragraph_small_class():
+    """Test component has correct class when small size is specified"""
+    test_text = "A sentence"
+
+    actual = paragraph(test_text, ParagraphSizes.SMALL)
+
+    assert getattr(actual, "className") == "govuk-body-s"
+
+
+def test_paragraph_specify_default_class():
+    """Test component has correct class when default size is specified"""
+    test_text = "A sentence"
+
+    actual = paragraph(test_text, ParagraphSizes.DEFAULT)
+
+    assert getattr(actual, "className") == "govuk-body"
+
+
+def test_paragraph_specify_unknown_class():
+    """Test component raises ValueError when provided an invalid paragraph size."""
+    test_text = "A sentence"
+
+    pytest.raises(ValueError, paragraph, test_text, "abc")


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [x] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Added a new paragraph component to the package, that allows a `<p>` to be created with one of 3 preset sizes (Lead, Default, Small)


<img width="1266" alt="Screenshot 2022-05-05 at 16 40 41" src="https://user-images.githubusercontent.com/102232401/166961135-f10ff0ec-4649-4b7a-b0fc-0b44e966fd4d.png">

