### PR TITLE
Enabling Docstring linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+load-plugins=pylint.extensions.docparams

--- a/gov_uk_dashboards/components/plotly/filter_panel.py
+++ b/gov_uk_dashboards/components/plotly/filter_panel.py
@@ -11,9 +11,8 @@ def filter_panel(children):
     on the dashboard.
 
     Args:
-        children: Dash HTML elements representing the individual selection
-        and filtering widgets.
-        E.g.dropdown menus, sliders, text input boxes etc.
+        children (list): Dash HTML elements representing the individual selection
+            and filtering widgets. E.g.dropdown menus, sliders, text input boxes etc.
     """
     return row_component(
         html.Div(

--- a/gov_uk_dashboards/components/plotly/paragraph.py
+++ b/gov_uk_dashboards/components/plotly/paragraph.py
@@ -26,6 +26,9 @@ def paragraph(
 
     Returns:
         html.P: The dash HTML object for a paragraph.
+
+    Raises:
+        ValueError: If the paragraph size supplied is not a valid size.
     """
     if size not in list(ParagraphSizes):
         raise ValueError(

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -20,7 +20,7 @@ def table_from_dataframe(
 
 
     Args:
-        df (DataFrame): Dataframe containing formatted data to display.
+        dataframe (DataFrame): Dataframe containing formatted data to display.
         title (str, optional): Title to display above the table. Defaults to None.
         include_headers (bool, optional): If the column labels should be included as headers.
             Defaults to True.

--- a/gov_uk_dashboards/figures/line_chart.py
+++ b/gov_uk_dashboards/figures/line_chart.py
@@ -31,6 +31,8 @@ def line_chart(
             the categories in the category column (if supplied), and values that are
             LineStyle data objects to set out the style of the corresponding line.
             Defaults to None.
+        **px_line_kwargs: Any other keyword arguments to pass to the plotly express
+            line graph function.
 
     Returns:
         plotly.Figure: The generated line chart figure object.


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Enabled a pylint extension that lints the docstrings in the code. This checker verifies that all function, method, and constructor docstrings include documentation of the:
- parameters and their types
- return value and its type
- exceptions raised
![image](https://user-images.githubusercontent.com/97545171/167376569-4dc30df7-1d56-4975-bbbf-53770f9cbe6d.png)


Additionally, fixed the issues it identified.