### PR TITLE
Update __init__.py's to simplify imports and provide documentation to users

### DIFF
--- a/gov_uk_dashboards/__init__.py
+++ b/gov_uk_dashboards/__init__.py
@@ -21,3 +21,9 @@ Contains the following modules:
 Contains the following function:
 - read_template: Return the government html template as a str for Plotly.
 """
+from . import components
+from . import figures
+from . import axes
+from . import formatting
+from . import colours
+from .template import read_template

--- a/gov_uk_dashboards/__init__.py
+++ b/gov_uk_dashboards/__init__.py
@@ -1,0 +1,23 @@
+"""A package containing functionality which is common to UK Government plotly
+dashboards.
+
+Contains the following modules:
+- components: Module containing submodules for building GOV.UK Design System
+    dashboards using different systems.
+    - plotly: Module containing Plotly/Dash components for building GOV.UK
+        Design System dashboards.
+- figures: Module containing standard Plotly figures for use in dashboards.
+    - enums: Module containing enums used in the construction of plotly figures.
+    - styles: Module containing classes & functions used for styling plotly
+        figures.
+- axes: Module containing functions related to graph axes.
+- formatting: Module containing tools to assist with formatting of numbers in
+    dashboards.
+    - rounding: Module containing functions to round data to the standard
+        rounding needed for display.
+- colours: Module containing Enums for Gov.UK colours and ONS Accessible
+    Colours.
+
+Contains the following function:
+- read_template: Return the government html template as a str for Plotly.
+"""

--- a/gov_uk_dashboards/axes.py
+++ b/gov_uk_dashboards/axes.py
@@ -1,4 +1,10 @@
-"""Function for calculating the axis range"""
+"""Module containing functions related to graph axes.
+
+Contains:
+- calc_axis_range: Return a range for a column of a dataframe so the derived
+    axis is at the origin or the lowest negative value in the column, whichever
+    is lower.
+"""
 from math import floor, ceil
 import pandas as pd
 

--- a/gov_uk_dashboards/colours.py
+++ b/gov_uk_dashboards/colours.py
@@ -1,4 +1,10 @@
-"""govuk_colors"""
+"""Module containing Enums for Gov.UK colours and ONS Accessible Colours.
+
+Contains:
+- GovUKColours: From the GOV.UK colour scheme:
+    https://design-system.service.gov.uk/styles/colour/
+- ONSAccessibleColours: ONS colours taken from the Subnational Indicators Explorer.
+"""
 from enum import Enum
 
 

--- a/gov_uk_dashboards/components/__init__.py
+++ b/gov_uk_dashboards/components/__init__.py
@@ -1,0 +1,7 @@
+"""Module containing submodules for building GOV.UK Design System dashboards
+using different systems.
+
+Contains:
+- plotly: Module containing Plotly/Dash components
+"""
+from . import plotly

--- a/gov_uk_dashboards/components/plotly/__init__.py
+++ b/gov_uk_dashboards/components/plotly/__init__.py
@@ -1,0 +1,84 @@
+"""Module containing Plotly/Dash components for building GOV.UK Design System dashboards.
+
+See: https://design-system.service.gov.uk/components/
+
+Contains:
+- message_banner: Return a changelog banner to be used to communicate to the
+    user when the dashboard was last updated.
+- card: Return a rectangle with a grey background. Mostly used to wrap
+    individual visualisations.
+- card_full_width: Return a card with a grey background that fits the full
+    width of its parent container using CSS flexbox.
+- empty_card: Return an empty card that is hidden to help keep alignment with
+    rows and columns.
+- collapsible_panel: Return a component that allows the user to open and close
+    a collapsible panel containing child components.
+- dashboard_container: Return a HTML wrapper for a whole dashboard.
+- details: Return HTML component for showing a summary expandable with more
+    information beneath.
+- filter_panel: Return a card with a title that allows the user to select and
+    filter metrics on the dashboard.
+- hidden_filter: Return an empty, invisible HTML element that stands in for a
+    filter component.
+- footer: Return a component for a Gov.UK standard footer.
+- graph: Takes a Plotly Figure and returns a responsive Dash graph with useful
+    defaults.
+- header: Return a header with the dashboard title.
+- heading1: Return a H1 Dash component with gov.uk styling
+- heading2: Return a H1 Dash component with gov.uk styling
+- heading3: Return a H1 Dash component with gov.uk styling
+    - HeadingSizes: Enum of sizes that can be used to manually adjust
+        text size for heading function returns.
+- html_list: Return either a <ul> or <ol> component, with the children set as
+    a list of <li> components matching the list_items provided.
+- key_value_pair: Return an element that displays a value (such as a metric)
+    labelled by a key (such as the name of the metric).
+- main_content: Return wrapper for the main content of the dashboard,
+    containing visualisations.
+- navbar: Return a navigation bar for switching between dashboards.
+    - navbar_link: Return a link for use with the navbar.
+    - navbar_link_active: Return a link that appears highlighted, suggesting to
+        the user that they are already viewing the linked dashboard.
+- side_navbar: Return a navigation bar for switching between dashboards.
+    - side_navbar_link: Return a link for use with the side_navbar.
+    - side_navbar_link_active: Return a link that appears highlighted,
+        suggesting to the user that they are already viewing the linked
+        dashboard.
+- no_data_message: Return a list of strings with a message for when
+    selection does not provide data.
+- paragraph: Return a formatted <p> html component with the children provided.
+    - ParagraphSizes: Enum for use with paragraph to specify the text size.
+- phase_banner_with_feedback: Return a phase banner with a feedback link,
+    which can be specified.
+- row_component: Returns a horizontal row used to contain cards.
+- table_from_dataframe: Return a html table created from a pandas DataFrame.
+- tooltip_title: Return a tooltip component for explaining details.
+- format_visualisation_commentary: Return paragraph styling commentary.
+- format_visualisation_title: Return a default formatted title for a
+    visualisation.
+"""
+
+from .banners import message_banner
+from .card import card, empty_card
+from .card_full_width import card_full_width
+from .collapsible_panel import collapsible_panel
+from .dashboard_container import dashboard_container
+from .details import details
+from .filter_panel import filter_panel, hidden_filter
+from .footer import footer
+from .graph import graph
+from .header import header
+from .heading import heading1, heading2, heading3, HeadingSizes
+from .html_list import html_list
+from .key_value_pair import key_value_pair
+from .main_content import main_content
+from .navbar import navbar, navbar_link, navbar_link_active
+from .no_data_message import no_data_message
+from .paragraph import paragraph, ParagraphSizes
+from .phase_banner import phase_banner_with_feedback
+from .row_component import row_component
+from .side_navbar import side_navbar
+from .table import table_from_dataframe
+from .tooltip_title import tooltip_title
+from .visualisation_commentary import format_visualisation_commentary
+from .visualisation_title import format_visualisation_title

--- a/gov_uk_dashboards/components/plotly/details.py
+++ b/gov_uk_dashboards/components/plotly/details.py
@@ -4,7 +4,7 @@ from dash import html
 
 def details(details_summary: str, details_text: str) -> html.Details:
     """
-    HTML component for showing a summary exapandable with more information beneath.
+    HTML component for showing a summary expandable with more information beneath.
 
     Makes a page easier to scan by letting users reveal more detailed information
     only if they need it.

--- a/gov_uk_dashboards/components/plotly/html_list.py
+++ b/gov_uk_dashboards/components/plotly/html_list.py
@@ -6,7 +6,8 @@ def html_list(
     list_items: list[str], *, numbered_list: bool = False, extra_spacing: bool = False
 ):
     """Create either a <ul> or <ol> component, with the children set as a list of <li>
-    components matching the list_items provided"""
+    components matching the list_items provided.
+    """
     li_items = [html.Li(x) for x in list_items]
 
     classes = ["govuk-list"]

--- a/gov_uk_dashboards/figures/__init__.py
+++ b/gov_uk_dashboards/figures/__init__.py
@@ -1,4 +1,16 @@
-"""Simplify namespace for importing figures"""
+"""Module containing standard Plotly figures for use in dashboards.
+
+Contains:
+- ChartData: A dataclass for containing standard information useful for
+    plotting charts.
+- line_chart: Create and return a plotly express line chart with
+    standard formatting.
+- enums: Module containing enums used in the construction of plotly figures.
+    - DashPatterns: Sets out valid dash patterns used by plotly/plotly express.
+- styles: Module containing classes & functions used for styling plotly figures.
+    - LineStyle: Dataclass containing information on how to style a line on a line
+        chart.
+"""
 from . import enums
 from . import styles
 from .chart_data import ChartData

--- a/gov_uk_dashboards/figures/enums/__init__.py
+++ b/gov_uk_dashboards/figures/enums/__init__.py
@@ -1,2 +1,6 @@
-"""Simplify namespace for importing enums"""
+"""Module containing enums used in the construction of plotly figures.
+
+Contains:
+- DashPatterns: Sets out valid dash patterns used by plotly/plotly express.
+"""
 from .dash_patterns import DashPatterns

--- a/gov_uk_dashboards/figures/styles/__init__.py
+++ b/gov_uk_dashboards/figures/styles/__init__.py
@@ -1,2 +1,7 @@
-"""Simplify namespace for importing styles"""
+"""Module containing classes and functions used for styling plotly figures.
+
+Contains:
+- LineStyle: Dataclass containing information on how to style a line on a line
+    chart.
+"""
 from .line_style import LineStyle

--- a/gov_uk_dashboards/formatting/__init__.py
+++ b/gov_uk_dashboards/formatting/__init__.py
@@ -1,0 +1,11 @@
+"""Module containing tools to assist with formatting of numbers in dashboards.
+
+Contains:
+- format_as_human_readable: Format a number as a human readable string, with
+    options to customise elements such as prefix and suffix.
+- rounding: Functions to round data to the standard rounding we want for display.
+    - round_thousands_to_1dp: Rounds values to 1dp in steps of 1000.
+"""
+
+from .human_readable import format_as_human_readable
+from . import rounding

--- a/gov_uk_dashboards/formatting/human_readable.py
+++ b/gov_uk_dashboards/formatting/human_readable.py
@@ -1,4 +1,4 @@
-"""Functions for converting values to human readable format"""
+"""Functions for converting values to human readable format."""
 import math
 from typing import Optional
 

--- a/gov_uk_dashboards/formatting/rounding.py
+++ b/gov_uk_dashboards/formatting/rounding.py
@@ -1,4 +1,9 @@
-"""Functions to round data to the standard rounding we want for display"""
+"""Module containing functions to round data to the standard rounding needed
+for display.
+
+Contains:
+- round_thousands_to_1dp: Rounds values to 1dp in steps of 1000.
+"""
 
 
 def round_thousands_to_1dp(value: float) -> float:


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [x] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Our package now has quite a lot in it. This makes it hard to know what's there or how to access it without reading through the repo/downloading it and having a look. It'd be better if users had some documentation of what it contained.

As such, this PR updates the `__init__.py`s to do 3 things:
- Provide additional documentation to users of the packages through docstrings.
  - If you hover over an imported module, it will explain what it contains with a short description of each module/function.
  - ![image](https://user-images.githubusercontent.com/97545171/168611550-5d2373c8-0406-459c-ad25-bf62c14df7c9.png)
- Simplify imports - where redundant names existed, these are imported in the parent module. This should make the package a little less cumbersome to use.
  - e.g. `from gov_uk_dashboards.components.plotly.paragraph import paragraph` can now be `from gov_uk_dashboards.components.plotly import paragraph`.
  - This is a non-breaking change, previous ways of importing will still work.
- Allow access of submodules of imported modules.
  - e.g. you can now do `from gov_uk_dashboards import formatting` and then use `formatting.format_as_human_readable(x)`. This previously would not have worked.
  - This can help reduce the large stacks of imports at the beginning of our files and leave a clear indication in the code where functions are being imported from. E.g. if you see the line `format_as_human_readable(x)`, it is not clear where this function is defined - in this file, in an imported package, or another module in this codebase? Providing breadcrumbs helps with this.

I've not increased the version number as non-essential change, and can be folded in with the next release - feel free to disagree with this though!