### PR TITLE
Add accessible captioned_figure component

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
   - black=22.3.0
   - numpy=1.22.0
   - pandas=1.3
+  - plotly=5.5.0
   - dash-bootstrap-components=1.0.3

--- a/gov_uk_dashboards/components/plotly/__init__.py
+++ b/gov_uk_dashboards/components/plotly/__init__.py
@@ -5,6 +5,8 @@ See: https://design-system.service.gov.uk/components/
 Contains:
 - message_banner: Return a changelog banner to be used to communicate to the
     user when the dashboard was last updated.
+- captioned_figure: Return figure with attached captions that can be read
+    by a screen reader.
 - card: Return a rectangle with a grey background. Mostly used to wrap
     individual visualisations.
 - card_full_width: Return a card with a grey background that fits the full
@@ -59,6 +61,7 @@ Contains:
 """
 
 from .banners import message_banner
+from .captioned_figure import captioned_figure
 from .card import card, empty_card
 from .card_full_width import card_full_width
 from .collapsible_panel import collapsible_panel

--- a/gov_uk_dashboards/components/plotly/captioned_figure.py
+++ b/gov_uk_dashboards/components/plotly/captioned_figure.py
@@ -2,7 +2,6 @@
 from typing import Any, Optional, Union
 import plotly
 import dash
-from gov_uk_dashboards.components.plotly.graph import graph
 
 
 def captioned_figure(
@@ -12,7 +11,7 @@ def captioned_figure(
         list[dash.development.base_component.Component],
     ],
     figure_name: str,
-    style: Optional[dict[str, Any]] = None,
+    graph_style: Optional[dict[str, Any]] = None,
 ):
     """
     Return figure with attached caption that can be read by a screen reader.
@@ -27,23 +26,31 @@ def captioned_figure(
         captions (Component, list[Component]): The captions to apply to the
             figure to be read by a screen reader.
         figure_name (str): Identifier for the figure. Should be lower case,
-            with words separated by dashes.
-        style (Optional[dict], optional): Any custom style to apply to the graph.
+            with words separated by dashes, e.g. jitter-figure
+        graph_style (Optional[dict], optional): Any custom style to apply to the graph.
             Defaults to None.
 
     Returns:
         dash.html.Figure: Figure html element containing the graph and its caption.
     """
+    if not graph_style:
+        graph_style = {}
+
+    if "height" not in graph_style.keys():
+        graph_style["height"] = "450px"
+
     return dash.html.Figure(
         [
             dash.html.Div(
-                children=graph(
-                    element_id=f"{figure_name}-figure",
+                children=dash.dcc.Graph(
+                    id=f"{figure_name}-graph",
+                    responsive=True,
                     figure=figure,
-                    style=style,
+                    style=graph_style,
+                    config={"displayModeBar": False},
                 ),
                 **{"role": "img", "aria-labelledby": f"{figure_name}-caption"},
-                id=f"{figure_name}-graph",
+                id=f"{figure_name}-figure",
             ),
             dash.html.Figcaption(
                 children=captions,

--- a/gov_uk_dashboards/components/plotly/captioned_figure.py
+++ b/gov_uk_dashboards/components/plotly/captioned_figure.py
@@ -2,7 +2,7 @@
 from typing import Any, Optional, Union
 import plotly
 import dash
-import gov_uk_dashboards.components.plotly
+from gov_uk_dashboards.components.plotly.graph import graph
 
 
 def captioned_figure(
@@ -37,7 +37,7 @@ def captioned_figure(
     return dash.html.Figure(
         [
             dash.html.Div(
-                children=gov_uk_dashboards.components.plotly.graph(
+                children=graph(
                     element_id=f"{figure_name}-figure",
                     figure=figure,
                     style=style,

--- a/gov_uk_dashboards/components/plotly/captioned_figure.py
+++ b/gov_uk_dashboards/components/plotly/captioned_figure.py
@@ -1,0 +1,54 @@
+"""captioned_figure function"""
+from typing import Any, Optional, Union
+import plotly
+import dash
+import gov_uk_dashboards.components.plotly
+
+
+def captioned_figure(
+    figure: plotly.graph_objects.Figure,
+    captions: Union[
+        dash.development.base_component.Component,
+        list[dash.development.base_component.Component],
+    ],
+    figure_name: str,
+    style: Optional[dict[str, Any]] = None,
+):
+    """
+    Return figure with attached caption that can be read by a screen reader.
+
+    The caption will not be displayed to users viewing the website through a
+    browser but is available for the a screen reader to describe.
+
+    The supplied graph and caption are wrapped in an HTML <figure > element.
+
+    Args:
+        figure (plotly.graph_objects.Figure): The plotly figure to display and caption.
+        captions (Component, list[Component]): The captions to apply to the
+            figure to be read by a screen reader.
+        figure_name (str): Identifier for the figure. Should be lower case,
+            with words separated by dashes.
+        style (Optional[dict], optional): Any custom style to apply to the graph.
+            Defaults to None.
+
+    Returns:
+        dash.html.Figure: Figure html element containing the graph and its caption.
+    """
+    return dash.html.Figure(
+        [
+            dash.html.Div(
+                children=gov_uk_dashboards.components.plotly.graph(
+                    element_id=f"{figure_name}-figure",
+                    figure=figure,
+                    style=style,
+                ),
+                **{"role": "img", "aria-labelledby": f"{figure_name}-caption"},
+                id=f"{figure_name}-graph",
+            ),
+            dash.html.Figcaption(
+                children=captions,
+                id=f"{figure_name}-caption",
+                className="govuk-visually-hidden",
+            ),
+        ]
+    )

--- a/gov_uk_dashboards/components/plotly/graph.py
+++ b/gov_uk_dashboards/components/plotly/graph.py
@@ -1,4 +1,5 @@
 """Create a graph"""
+import warnings
 from dash import dcc
 
 
@@ -7,7 +8,16 @@ def graph(element_id: str, figure: any, style: dict = None):
     Create a responsive dash graph.
     Forces the default height of 450px that plotly uses for
     graphs if style is not specified.
+
+    WARNING: graph will be deprecated in a future version of gov_uk_dashboards.
+        Use captioned_figure for accessibility reasons.
     """
+    warnings.warn(
+        "graph will be deprecated in a future version of gov_uk_dashboards. "
+        "Use captioned_figure instead for accessibility reasons.",
+        PendingDeprecationWarning,
+    )
+
     if not style:
         style = {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dash~=2.0.0
 numpy>=1.22.0
 pandas>=1.3
 dash_bootstrap_components~=1.1.0
+plotly~=5.5.0

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "numpy>=1.22.0",
         "dash_bootstrap_components~=1.1.0",
         "pandas>=1.3",
+        "plotly~=5.5.0",
     ],
     package_data={"": ["gov_uk_dashboards/template.html"]},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.4.3",
+    version="4.5.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Implement a generic captioned figure following the model in the Local Government dashboard. This displays a plotly figure with an attached caption which is not normally displayed but is available to be read by screen readers. This is wrapped in a html `<figure>` element to aid assistive technologies.