### PR TITLE
fix: row and card should always be a div

### DIFF
--- a/gov_uk_dashboards/components/plotly/card.py
+++ b/gov_uk_dashboards/components/plotly/card.py
@@ -5,7 +5,7 @@ from dash import html
 def card(children):
     """A rectangle with a grey background.
     Mostly used to wrap individual visualisations, e.g. a gauge."""
-    return html.Li(children, className="mini-card")
+    return html.Div(children, className="mini-card")
 
 
 def empty_card():

--- a/gov_uk_dashboards/components/plotly/card_full_width.py
+++ b/gov_uk_dashboards/components/plotly/card_full_width.py
@@ -9,4 +9,4 @@ def card_full_width(children):
 
     See https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout for more information.
     """
-    return html.Li(children, className="mini-card", style={"flex": "1 1 100%"})
+    return html.Div(children, className="mini-card", style={"flex": "1 1 100%"})

--- a/gov_uk_dashboards/components/plotly/row_component.py
+++ b/gov_uk_dashboards/components/plotly/row_component.py
@@ -11,6 +11,6 @@ def row_component(cards):
 
     See https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout for more information.
     """
-    return html.Ul(
+    return html.Div(
         cards, className="govuk-list card-container", style={"alignItems": "stretch"}
     )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.5.0",
+    version="4.6.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
Signed-off-by: Jordan Hall <jordan@libertyware.co.uk>

## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
