### PR TITLE
fix: repair templating

### DIFF
--- a/gov_uk_dashboards/template.html
+++ b/gov_uk_dashboards/template.html
@@ -11,16 +11,8 @@
   </head>
   <body class="govuk-template__body">
     {%app_entry%}
-    <footer>{%config%} {%scripts%} {%renderer%}</footer>
-    <script>
-      document.body.className = document.body.className
-        ? document.body.className + ' js-enabled'
-        : 'js-enabled';
-    </script>
-    <!-- component HTML -->
-    <script src="/assets/govuk-frontend-3.14.0.min.js"></script>
-    <script>
-      window.GOVUKFrontend.initAll();
-    </script>
+    {%config%}
+    {%scripts%}
+    {%renderer%}
   </body>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.6.0",
+    version="4.6.1",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",


### PR DESCRIPTION
Signed-off-by: Jordan Hall <jordan@libertyware.co.uk>

## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Scripts tags should always come OUTSIDE of any tags within the <body> and at the footer.

The GovUK wont actually work with plotly due to the generation of the code.

As the JS code gets added via assets. If you do hack the govuk JS to work then you just need to add the script there not in the template 