### PR TITLE
Added option to captioned_figure for displaying figure on desktop only

### DIFF
--- a/gov_uk_dashboards/components/plotly/captioned_figure.py
+++ b/gov_uk_dashboards/components/plotly/captioned_figure.py
@@ -11,7 +11,9 @@ def captioned_figure(
         list[dash.development.base_component.Component],
     ],
     figure_name: str,
+    *,
     graph_style: Optional[dict[str, Any]] = None,
+    desktop_only: bool = False,
 ):
     """
     Return figure with attached caption that can be read by a screen reader.
@@ -29,6 +31,8 @@ def captioned_figure(
             with words separated by dashes, e.g. jitter-figure
         graph_style (Optional[dict], optional): Any custom style to apply to the graph.
             Defaults to None.
+        desktop_only (bool, optional): Whether the figure should be replaced with
+            the caption when viewed on mobile. Defaults to False.
 
     Returns:
         dash.html.Figure: Figure html element containing the graph and its caption.
@@ -49,13 +53,16 @@ def captioned_figure(
                     style=graph_style,
                     config={"displayModeBar": False},
                 ),
+                className="jitter-desktop-only" if desktop_only else "",
                 **{"role": "img", "aria-labelledby": f"{figure_name}-caption"},
                 id=f"{figure_name}-figure",
             ),
             dash.html.Figcaption(
                 children=captions,
                 id=f"{figure_name}-caption",
-                className="govuk-visually-hidden",
+                className="govuk-visually-hidden-desktop-only"
+                if desktop_only
+                else "govuk-visually-hidden",
             ),
         ]
     )


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
To fix issue with displaying jitters on mobile, added option to captioned_figure to only show on desktop and otherwise should caption.