### PR TITLE
Add formatter to table options

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,3 @@
 [MASTER]
 load-plugins=pylint.extensions.docparams
+max-args = 7

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -5,12 +5,14 @@ from dash import html
 
 
 def table_from_dataframe(
-    dataframe: DataFrame,
-    title: Optional[str] = None,
-    include_headers: bool = True,
-    first_column_is_header: bool = True,
-    title_is_subtitle: bool = False,
-    **table_properties
+        dataframe: DataFrame,
+        title: Optional[str] = None,
+        include_headers: bool = True,
+        first_column_is_header: bool = True,
+        title_is_subtitle: bool = False,
+        first_column_formatter: Optional = None,
+        columns_to_exclude: Optional[list[str]] = [],
+        **table_properties
 ):
     """
     Displays a pandas DataFrame as a table formatted in the Gov.UK style
@@ -20,6 +22,7 @@ def table_from_dataframe(
 
 
     Args:
+
         dataframe (DataFrame): Dataframe containing formatted data to display.
         title (str, optional): Title to display above the table. Defaults to None.
         include_headers (bool, optional): If the column labels should be included as headers.
@@ -28,13 +31,21 @@ def table_from_dataframe(
             Defaults to True.
         title_is_subtitle (bool, optional): Sets if the title should be displayed as a subtitle
             or full title. Defaults to False.
+        first_column_formatter: a function that will be provided a dataframe:pd.dataFrame,
+            row:pd.Series and index:int that can be used to reformat the first column
+        columns_to_exclude: A list of column names to exclude from displaying in the table
         **table_properties: Any additional arguments for the html.Table object,
             such as setting a width or id.
 
     Returns:
         html.Table: The dash HTML object for the table.
     """
+    if first_column_formatter is None:
+        first_column_formatter = lambda df, row, index: row[index]
+
     table_contents = []
+
+    filtered_dataframe = dataframe.loc[:, ~dataframe.columns.isin(columns_to_exclude)]
 
     if title:
         table_contents.append(
@@ -52,7 +63,7 @@ def table_from_dataframe(
                 html.Tr(
                     [
                         html.Th(header, scope="col", className="govuk-table__header")
-                        for header in dataframe.columns
+                        for header in filtered_dataframe.columns
                     ],
                     className="govuk-table__row",
                 ),
@@ -64,14 +75,25 @@ def table_from_dataframe(
         html.Tbody(
             [
                 html.Tr(
-                    [html.Th(row[0], scope="row", className="govuk-table__header")]
+                    (
+                        [
+                            html.Th(
+                                first_column_formatter(dataframe, row, index),
+                                scope="row",
+                                className="govuk-table__header",
+                            )
+                        ]
+                        if first_column_is_header
+                        else [
+                            html.Td(
+                                first_column_formatter(dataframe, row, index),
+                                className="govuk-table__cell",
+                            )
+                        ]
+                    )
                     + [html.Td(cell, className="govuk-table__cell") for cell in row[1:]]
                 )
-                if first_column_is_header
-                else html.Tr(
-                    [html.Td(cell, className="govuk-table__cell") for cell in row]
-                )
-                for _, row in dataframe.iterrows()
+                for index, row in filtered_dataframe.iterrows()
             ],
             className="govuk-table__body",
         )

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -5,14 +5,14 @@ from dash import html
 
 
 def table_from_dataframe(
-        dataframe: DataFrame,
-        title: Optional[str] = None,
-        include_headers: bool = True,
-        first_column_is_header: bool = True,
-        title_is_subtitle: bool = False,
-        first_column_formatter: Optional = None,
-        columns_to_exclude: Optional[list[str]] = [],
-        **table_properties
+    dataframe: DataFrame,
+    title: Optional[str] = None,
+    include_headers: bool = True,
+    first_column_is_header: bool = True,
+    title_is_subtitle: bool = False,
+    first_column_formatter: Optional = None,
+    columns_to_exclude: Optional[list[str]] = [],
+    **table_properties
 ):
     """
     Displays a pandas DataFrame as a table formatted in the Gov.UK style

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -11,7 +11,7 @@ def table_from_dataframe(
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,
     first_column_formatter: Optional = None,
-    columns_to_exclude: Optional[list[str]] = [],
+    columns_to_exclude: Optional[list[str]] = None,
     **table_properties
 ):
     """
@@ -45,7 +45,11 @@ def table_from_dataframe(
 
     table_contents = []
 
-    filtered_dataframe = dataframe.loc[:, ~dataframe.columns.isin(columns_to_exclude)]
+    filtered_dataframe = (
+        dataframe
+        if columns_to_exclude is None
+        else dataframe.loc[:, ~dataframe.columns.isin(columns_to_exclude)]
+    )
 
     if title:
         table_contents.append(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.7.0",
+    version="4.8.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8.0",

--- a/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
+++ b/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
@@ -1,7 +1,5 @@
 """Tests for the table component"""
 import pandas
-import pytest
-from dash import html
 
 from gov_uk_dashboards.components.plotly.table import table_from_dataframe
 

--- a/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
+++ b/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
@@ -5,9 +5,11 @@ from dash import html
 
 from gov_uk_dashboards.components.plotly.table import table_from_dataframe
 
-df = pandas.DataFrame(columns=["Col1", "Col2", "Col3"],
-                          data=[["1,1", "1,2", "1,3"],
-                          ["2,1", "2,2", "2,3"]])
+df = pandas.DataFrame(
+    columns=["Col1", "Col2", "Col3"],
+    data=[["1,1", "1,2", "1,3"], ["2,1", "2,2", "2,3"]],
+)
+
 
 def test_table_shows_all_columns():
     table = table_from_dataframe(df)
@@ -15,15 +17,16 @@ def test_table_shows_all_columns():
 
 
 def test_table_hides_columns_when_they_are_provided():
-    table = table_from_dataframe(df, columns_to_exclude=['Col2'])
+    table = table_from_dataframe(df, columns_to_exclude=["Col2"])
     assert len(table.children[0].children.children) == 2
 
 
 def test_first_column_formatter_produces_expected_value_in_first_column_when_provided():
     def hello_world(df, row, index):
-        if index%2 == 0:
+        if index % 2 == 0:
             return "hello"
         return "world"
+
     table = table_from_dataframe(df, first_column_formatter=hello_world)
     assert table.children[1].children[0].children[0].children == "hello"
     assert table.children[1].children[0].children[2].children == "1,3"

--- a/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
+++ b/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
@@ -5,18 +5,27 @@ from dash import html
 
 from gov_uk_dashboards.components.plotly.table import table_from_dataframe
 
+df = pandas.DataFrame(columns=["Col1", "Col2", "Col3"],
+                          data=[["1,1", "1,2", "1,3"],
+                          ["2,1", "2,2", "2,3"]])
 
 def test_table_shows_all_columns():
-    df = pandas.DataFrame(columns=["Col1", "Col2", "Col3"],
-                          data=[["1,1", "1,2", "1,3"]])
     table = table_from_dataframe(df)
-
     assert len(table.children[0].children.children) == 3
 
 
 def test_table_hides_columns_when_they_are_provided():
-    assert True
+    table = table_from_dataframe(df, columns_to_exclude=['Col2'])
+    assert len(table.children[0].children.children) == 2
 
 
 def test_first_column_formatter_produces_expected_value_in_first_column_when_provided():
-    assert True
+    def hello_world(df, row, index):
+        if index%2 == 0:
+            return "hello"
+        return "world"
+    table = table_from_dataframe(df, first_column_formatter=hello_world)
+    assert table.children[1].children[0].children[0].children == "hello"
+    assert table.children[1].children[0].children[2].children == "1,3"
+    assert table.children[1].children[1].children[0].children == "world"
+    assert table.children[1].children[1].children[1].children == "2,2"

--- a/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
+++ b/tests/unit_tests/gov_uk_dashboards/components/plotly/test_table.py
@@ -1,0 +1,22 @@
+"""Tests for the table component"""
+import pandas
+import pytest
+from dash import html
+
+from gov_uk_dashboards.components.plotly.table import table_from_dataframe
+
+
+def test_table_shows_all_columns():
+    df = pandas.DataFrame(columns=["Col1", "Col2", "Col3"],
+                          data=[["1,1", "1,2", "1,3"]])
+    table = table_from_dataframe(df)
+
+    assert len(table.children[0].children.children) == 3
+
+
+def test_table_hides_columns_when_they_are_provided():
+    assert True
+
+
+def test_first_column_formatter_produces_expected_value_in_first_column_when_provided():
+    assert True


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`


### PR Description:
Add formatter to table options in package. This formatter will allow for the first column of the table to be re-formatted, for example: to include a hyperlink to the data source.