### PR TITLE
The reset/clear button should identify as button

### DIFF
--- a/gov_uk_dashboards/components/plotly/filter_panel.py
+++ b/gov_uk_dashboards/components/plotly/filter_panel.py
@@ -25,6 +25,7 @@ def filter_panel(children):
                             "Clear all selections",
                             className="govuk-button govuk-button--warning govuk-!-margin-0",
                             href="?",
+                            role="button",
                         ),
                         style={"width": "100%"},
                     ),


### PR DESCRIPTION
Adding role button will say this A link is acting like a button. The reset is a hacky callback that basically removes the search string from the address bar. This always felt like a button than the definition of a link
