### PR TITLE
Add extra class to sidebar navigation component

### DIFF
--- a/gov_uk_dashboards/components/plotly/side_navbar.py
+++ b/gov_uk_dashboards/components/plotly/side_navbar.py
@@ -7,8 +7,8 @@ from dash import html, dcc
 def side_navbar(links, identifier: Optional[str] = None):
     """A navigation bar for switching between dashboards."""
     return html.Nav(
-        html.Ul(links, className="moj-side-navigation__list"),
-        className="moj-side-navigation",
+        links,
+        className="moj-side-navigation moj-side-navigation__list",
         role="navigation",
         id=identifier if identifier is not None else "",
     )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.10.1",
+    version="4.11.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8",


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [x] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Add extra class to sidebar navigation component
Remove redundant `<ul>` component from the children of the Nav component

Before 
![image](https://user-images.githubusercontent.com/102232401/176219036-73a45e2d-bfef-468f-abbd-d922b20cc6c0.png)


After
![image](https://user-images.githubusercontent.com/102232401/176219168-75a3eca3-ce7e-49d6-8dcc-fd0339dc84c5.png)
