### PR TITLE
modify table to fix scrolling header issue

### DIFF
--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -10,8 +10,7 @@ def table_from_dataframe(
     include_headers: bool = True,
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,
-    short_table: bool = False
-    **table_properties
+    short_table: bool = False**table_properties,
 ):
     """
     Displays a pandas DataFrame as a table formatted in the Gov.UK style
@@ -57,7 +56,9 @@ def table_from_dataframe(
                     ],
                     className="govuk-table__row",
                 ),
-                className="govuk-table__head-short" if short_table else "govuk-table__head",
+                className="govuk-table__head-short"
+                if short_table
+                else "govuk-table__head",
             )
         )
 

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -7,10 +7,10 @@ from dash import html
 def table_from_dataframe(
     dataframe: DataFrame,
     title: Optional[str] = None,
-    include_headers: bool = True,
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,
-    short_table: bool = False**table_properties,
+    short_table: bool = False,
+    **table_properties,
 ):
     """
     Displays a pandas DataFrame as a table formatted in the Gov.UK style
@@ -22,12 +22,11 @@ def table_from_dataframe(
     Args:
         dataframe (DataFrame): Dataframe containing formatted data to display.
         title (str, optional): Title to display above the table. Defaults to None.
-        include_headers (bool, optional): If the column labels should be included as headers.
-            Defaults to True.
         first_column_is_header (bool, optional): Sets if the first column is a header column.
             Defaults to True.
         title_is_subtitle (bool, optional): Sets if the title should be displayed as a subtitle
             or full title. Defaults to False.
+        short_table: (bool, optional): sets if the header of the table should scroll with window.
         **table_properties: Any additional arguments for the html.Table object,
             such as setting a width or id.
 
@@ -46,21 +45,20 @@ def table_from_dataframe(
             )
         )
 
-    if include_headers:
-        table_contents.append(
-            html.Thead(
-                html.Tr(
-                    [
-                        html.Th(header, scope="col", className="govuk-table__header")
-                        for header in dataframe.columns
-                    ],
-                    className="govuk-table__row",
-                ),
-                className="govuk-table__head-short"
-                if short_table
-                else "govuk-table__head",
-            )
+    table_contents.append(
+        html.Thead(
+            html.Tr(
+                [
+                    html.Th(header, scope="col", className="govuk-table__header")
+                    for header in dataframe.columns
+                ],
+                className="govuk-table__row",
+            ),
+            className="govuk-table__head-short"
+            if short_table
+            else "govuk-table__head",
         )
+    )
 
     table_contents.append(
         html.Tbody(

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -26,7 +26,7 @@ def table_from_dataframe(
             Defaults to True.
         title_is_subtitle (bool, optional): Sets if the title should be displayed as a subtitle
             or full title. Defaults to False.
-        short_table: (bool, optional): sets if the header of the table should scroll with window.
+        short_table: (bool, optional): if False the header of the table will scroll with window.
         **table_properties: Any additional arguments for the html.Table object,
             such as setting a width or id.
 

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -10,6 +10,7 @@ def table_from_dataframe(
     include_headers: bool = True,
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,
+    short_table: bool = False
     **table_properties
 ):
     """
@@ -56,7 +57,7 @@ def table_from_dataframe(
                     ],
                     className="govuk-table__row",
                 ),
-                className="govuk-table__head",
+                className="govuk-table__head-short" if short_table else "govuk-table__head",
             )
         )
 

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -54,9 +54,7 @@ def table_from_dataframe(
                 ],
                 className="govuk-table__row",
             ),
-            className="govuk-table__head-short"
-            if short_table
-            else "govuk-table__head",
+            className="govuk-table__head-short" if short_table else "govuk-table__head",
         )
     )
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.14.1",
+    version="4.15.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.11.0",
+    version="4.11.1",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8",


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Modify table to allow for different behaviour of short tables (header doesn't scroll) and long tables (header does scroll). 

Removed include_headers argument as it isn't used for any of our tables (in LG or housing). 