### PR TITLE
Change incorrectly set package version to 4.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="4.17.1",
+    version="4.17.0",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8",


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Change incorrectly set package version to 4.17.0 after starting minor version from 1 instead of 0