### PR TITLE
Generalize the icon size increase for all graphs

### DIFF
--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -12630,7 +12630,7 @@ mark.expenditure {
   text-align: right;
 }
 
- #income_graph path.legendundefined, #Ofsted-ratings path.legendundefined {
+.dash-graph path.legendundefined {
   d: path("M 8 8 H -8 V -8 H 8 Z")
    /*By default plotly draws the icons using a 6x6 pixel square, however that isn't large enough
     to accurately display enough of the pattern used on a barchart. We've instead increased this


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Previously this was an opt-in for both the income and Ofsted graph.

We've tested this change against all charts within our dashboards and it results in all legends have an improved (larger) size.

Old legend size:
![image](https://user-images.githubusercontent.com/976274/188676160-3217e898-ec0f-4807-9ee7-b0b48572e3b2.png)

New legend size:
![image](https://user-images.githubusercontent.com/976274/188676059-661f1d29-8388-4d3b-be15-86103b7b3352.png)
