### PR TITLE
Increase spacing between nav bar elements

### DIFF
--- a/gov_uk_dashboards/components/plotly/side_navbar.py
+++ b/gov_uk_dashboards/components/plotly/side_navbar.py
@@ -29,5 +29,6 @@ def side_navbar_link_active(text, href):
     """
     return html.Li(
         dcc.Link(text, href=href, className="govuk-link govuk-link--no-visited-state"),
-        className="moj-side-navigation__item moj-side-navigation__item--active govuk-!-margin-bottom-1",
+        className=("moj-side-navigation__item moj-side-navigation__item--active "
+                    "govuk-!-margin-bottom-1"),
     )

--- a/gov_uk_dashboards/components/plotly/side_navbar.py
+++ b/gov_uk_dashboards/components/plotly/side_navbar.py
@@ -18,7 +18,7 @@ def side_navbar_link(text, href):
     """A link to another dashboard"""
     return html.Li(
         dcc.Link(text, href=href, className="govuk-link govuk-link--no-visited-state"),
-        className="moj-side-navigation__item",
+        className="moj-side-navigation__item govuk-!-margin-bottom-1",
     )
 
 
@@ -29,5 +29,5 @@ def side_navbar_link_active(text, href):
     """
     return html.Li(
         dcc.Link(text, href=href, className="govuk-link govuk-link--no-visited-state"),
-        className="moj-side-navigation__item moj-side-navigation__item--active",
+        className="moj-side-navigation__item moj-side-navigation__item--active govuk-!-margin-bottom-1",
     )

--- a/gov_uk_dashboards/components/plotly/side_navbar.py
+++ b/gov_uk_dashboards/components/plotly/side_navbar.py
@@ -29,6 +29,8 @@ def side_navbar_link_active(text, href):
     """
     return html.Li(
         dcc.Link(text, href=href, className="govuk-link govuk-link--no-visited-state"),
-        className=("moj-side-navigation__item moj-side-navigation__item--active "
-                    "govuk-!-margin-bottom-1"),
+        className=(
+            "moj-side-navigation__item moj-side-navigation__item--active "
+            "govuk-!-margin-bottom-1"
+        ),
     )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="6.0.0",
+    version="6.1.1",
     packages=find_packages(),
     install_requires=[
         "setuptools~=59.8",


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [x] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Margin added around list items for nav bar.

![image](https://user-images.githubusercontent.com/105639467/193281086-60c623cf-fb28-4712-b583-5d4f2cc817e6.png)
(some changes in screenshot come from local government dashboard PR)

Before:
![image](https://user-images.githubusercontent.com/105639467/193286214-f18b419a-a63c-4639-ba73-689e5586751a.png)
