### PR TITLE
Add action to check formatting of setup.py

### DIFF
--- a/.github/workflows/check-before-merging.yml
+++ b/.github/workflows/check-before-merging.yml
@@ -52,3 +52,10 @@ jobs:
           environment-file: environment.yml
       - name: Execute tests
         run: python -u -m pytest --headless tests
+
+  setup_check:
+    name: 'Check setup.py is formatted correctly'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: python setup.py check


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Add action to check formatting of setup.py

We believe this will be valuable because of an error when releasing v6.2.0 where we made a typo within the `install_requires` list.

This is the error that `setup.py check` would have given if we'd had this GitHub Action installed at the time:
```
error in gov_uk_dashboards setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Parse error at "'=0.2.0'": Expected stringEnd
```

Adding this check should reduce the amount of time wasted in the future if this typo is ever made again.