### PR TITLE
Change CDS query function so dashboard tests still run locally

### DIFF
--- a/gov_uk_dashboards/lib/dap/get_dataframe_from_cds.py
+++ b/gov_uk_dashboards/lib/dap/get_dataframe_from_cds.py
@@ -21,9 +21,12 @@ def get_data_from_cds_or_fallback_to_csv(
     Returns:
         pd.DataFrame
     """
-    if ("DATA_FOLDER_LOCATION" in os.environ and os.environ["DATA_FOLDER_LOCATION"] == "tests/") or ("STAGE" in os.environ and os.environ["STAGE"] == "testing"):
+    if (
+        "DATA_FOLDER_LOCATION" in os.environ
+        and os.environ["DATA_FOLDER_LOCATION"] == "tests/"
+    ) or ("STAGE" in os.environ and os.environ["STAGE"] == "testing"):
         return pd.read_csv(csv_path)
-    
+
     try:
         conn = pyodbc.connect(
             _get_pydash_connection_string(secret_name, cds_server_name)

--- a/gov_uk_dashboards/lib/dap/get_dataframe_from_cds.py
+++ b/gov_uk_dashboards/lib/dap/get_dataframe_from_cds.py
@@ -1,9 +1,11 @@
 """ Returns a dataframe after connecting to CDS, otherwise uses a csv already saved in the file"""
+import os
 import json
 import pandas as pd
 import pyodbc
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
+
 
 def get_data_from_cds_or_fallback_to_csv(
     cds_sql_query: str, csv_path: str, secret_name: str, cds_server_name: str
@@ -19,6 +21,9 @@ def get_data_from_cds_or_fallback_to_csv(
     Returns:
         pd.DataFrame
     """
+    if ("DATA_FOLDER_LOCATION" in os.environ and os.environ["DATA_FOLDER_LOCATION"] == "tests/") or ("STAGE" in os.environ and os.environ["STAGE"] == "testing"):
+        return pd.read_csv(csv_path)
+    
     try:
         conn = pyodbc.connect(
             _get_pydash_connection_string(secret_name, cds_server_name)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="7.0.1",
+    version="7.0.2",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Change CDS query function to dashboard tests still run locally. This checks environment variables to see if the data folder is set to "tests" (so that run.py --test-data works) or "STAGE" is set to "testing" (so that pytest works). 