### PR TITLE
Be able to set the text on the download button

### DIFF
--- a/gov_uk_dashboards/components/plotly/download_button.py
+++ b/gov_uk_dashboards/components/plotly/download_button.py
@@ -2,14 +2,17 @@
 from dash import html
 
 
-def download_button():
+def download_button(button_text: str):
     """
-    Return download button which is aligned to the right
+    Return a download button which is aligned to the right
+    
+    Args:
+    button_text (str): The text to display on the button.
     """
     return html.Div(
         [
             html.Button(
-                "Download data",
+                button_text,
                 id="download-button",
                 n_clicks=0,
                 className="govuk-button govuk-button--secondary",

--- a/gov_uk_dashboards/components/plotly/download_button.py
+++ b/gov_uk_dashboards/components/plotly/download_button.py
@@ -5,7 +5,7 @@ from dash import html
 def download_button(button_text: str):
     """
     Return a download button which is aligned to the right
-    
+
     Args:
     button_text (str): The text to display on the button.
     """

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="8.0.1",
+    version="9.0.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Add a parameter to the download button function so that the text displayed on it can be set. 
This is being done for this ticket https://trello.com/c/zGZf7miA and will also require changes to the building safety dashboard as it is a breaking change. 
