### PR TITLE
Add in default param so that the last row of a table can be unbolded

### DIFF
--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -10,7 +10,7 @@ def table_from_dataframe(
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,
     short_table: bool = True,
-    last_row_unbolded=False,
+    last_row_unbolded: bool = False,
     **table_properties,
 ):
     """
@@ -28,6 +28,8 @@ def table_from_dataframe(
         title_is_subtitle (bool, optional): Sets if the title should be displayed as a subtitle
             or full title. Defaults to False.
         short_table: (bool, optional): if False the header of the table will scroll with window.
+        last_row_unbolded: (bool, optional): Sets if the last row should not be bolded if
+            first_column_is_header is True. Defaults to False.
         **table_properties: Any additional arguments for the html.Table object,
             such as setting a width or id.
 

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -12,7 +12,7 @@ def table_from_dataframe(
     short_table: bool = True,
     last_row_unbolded: bool = False,
     **table_properties,
-): # pylint: disable=too-many-arguments
+):  # pylint: disable=too-many-arguments
     """
     Displays a pandas DataFrame as a table formatted in the Gov.UK style
 

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -10,7 +10,7 @@ def table_from_dataframe(
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,
     short_table: bool = True,
-    last_row_unbolded = False,
+    last_row_unbolded=False,
     **table_properties,
 ):
     """

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -10,6 +10,7 @@ def table_from_dataframe(
     first_column_is_header: bool = True,
     title_is_subtitle: bool = False,
     short_table: bool = True,
+    last_row_unbolded = False,
     **table_properties,
 ):
     """
@@ -58,6 +59,7 @@ def table_from_dataframe(
         )
     )
 
+    last_row_index = len(dataframe) - 1 if last_row_unbolded else len(dataframe)
     table_contents.append(
         html.Tbody(
             [
@@ -65,11 +67,11 @@ def table_from_dataframe(
                     [html.Th(row[0], scope="row", className="govuk-table__header")]
                     + [html.Td(cell, className="govuk-table__cell") for cell in row[1:]]
                 )
-                if first_column_is_header
+                if first_column_is_header and index != last_row_index
                 else html.Tr(
                     [html.Td(cell, className="govuk-table__cell") for cell in row]
                 )
-                for _, row in dataframe.iterrows()
+                for index, row in dataframe.iterrows()
             ],
             className="govuk-table__body",
         )

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -12,7 +12,7 @@ def table_from_dataframe(
     short_table: bool = True,
     last_row_unbolded: bool = False,
     **table_properties,
-):
+): # pylint: disable=too-many-arguments
     """
     Displays a pandas DataFrame as a table formatted in the Gov.UK style
 

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -88,4 +88,10 @@ def table_from_dataframe(
         )
     )
 
-    return html.Table(table_contents, className="govuk-table", **table_properties)
+    return html.Table(
+        table_contents,
+        className="govuk-table",
+        id="table",
+        role="table",
+        **table_properties,
+    )

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -1,7 +1,7 @@
 """Function for creating a table component from a dataframe"""
 from typing import Optional
 from pandas import DataFrame
-from dash import html
+from dash import html, dcc
 
 
 def table_from_dataframe(
@@ -11,6 +11,7 @@ def table_from_dataframe(
     title_is_subtitle: bool = False,
     short_table: bool = True,
     last_row_unbolded: bool = False,
+    format_column_headers_as_markdown: bool = False,
     **table_properties,
 ):  # pylint: disable=too-many-arguments
     """
@@ -30,6 +31,8 @@ def table_from_dataframe(
         short_table: (bool, optional): if False the header of the table will scroll with window.
         last_row_unbolded: (bool, optional): Sets if the last row should not be bolded if
             first_column_is_header is True. Defaults to False.
+        format_column_headers_as_markdown: (bool, optional): Sets if the column headers should
+            be formatted as markdown. Defaults to False.
         **table_properties: Any additional arguments for the html.Table object,
             such as setting a width or id.
 
@@ -52,7 +55,13 @@ def table_from_dataframe(
         html.Thead(
             html.Tr(
                 [
-                    html.Th(header, scope="col", className="govuk-table__header")
+                    html.Th(
+                        dcc.Markdown(header),
+                        scope="col",
+                        className="govuk-table__header",
+                    )
+                    if format_column_headers_as_markdown
+                    else html.Th(header, scope="col", className="govuk-table__header")
                     for header in dataframe.columns
                 ],
                 className="govuk-table__row",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.1.1",
+    version="9.2.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
