### PR TITLE
Csp frame ancestors

### DIFF
--- a/gov_uk_dashboards/lib/http_headers.py
+++ b/gov_uk_dashboards/lib/http_headers.py
@@ -1,8 +1,8 @@
 """http_headers"""
 
 
-import dash
 import os
+import dash
 
 
 def setup_application_http_response_headers(dash_app: dash.Dash):

--- a/gov_uk_dashboards/lib/http_headers.py
+++ b/gov_uk_dashboards/lib/http_headers.py
@@ -2,6 +2,7 @@
 
 
 import dash
+import os
 
 
 def setup_application_http_response_headers(dash_app: dash.Dash):
@@ -10,13 +11,18 @@ def setup_application_http_response_headers(dash_app: dash.Dash):
 
     @server.after_request
     def add_headers(response):
-        response.headers.add(
-            "Content-Security-Policy",
-            "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
-        )
+
+
+        content_security_policy = "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:"
+        frame_ancestors = os.environ.get("ALLOWED_FRAME_ANCESTORS")
+        if frame_ancestors:
+            content_security_policy += '; frame-ancestors ' + frame_ancestors
+        response.headers.add("Content-Security-Policy", content_security_policy)
+
         response.headers.add("X-Content-Type-Options", "nosniff")
-        response.headers.add("X-Frame-Options", "DENY")
         response.headers.add("Referrer-Policy", "no-referrer")
+        response.headers.add("X-Frame-Options", "DENY")
+
         # The below header will disable all browser features for the dashboard website
         response.headers.add(
             "Permission-Policy",

--- a/gov_uk_dashboards/lib/http_headers.py
+++ b/gov_uk_dashboards/lib/http_headers.py
@@ -12,11 +12,12 @@ def setup_application_http_response_headers(dash_app: dash.Dash):
     @server.after_request
     def add_headers(response):
 
-
-        content_security_policy = "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:"
+        content_security_policy = (
+            "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:"
+        )
         frame_ancestors = os.environ.get("ALLOWED_FRAME_ANCESTORS")
         if frame_ancestors:
-            content_security_policy += '; frame-ancestors ' + frame_ancestors
+            content_security_policy += "; frame-ancestors " + frame_ancestors
         response.headers.add("Content-Security-Policy", content_security_policy)
 
         response.headers.add("X-Content-Type-Options", "nosniff")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.3.0",
+    version="9.3.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:

The dashboards need to be loaded via iframe, but this doesn't work currently due to the X-Frame-Options = DENY header.

In modern browsers this is made obsolete by CSP frame ancestors: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors

I've modified http_headers.py to load an environment variable called ALLOWED_FRAME_ANCESTORS - if set, the specified frame ancestors will be added to the CSP. Otherwise, it will behave the same as before.

So, to load a dashboard in an iframe - in the Azure config for a dashboard, set the environment variable ALLOWED_FRAME_ANCESTORS to match the page where it should be loaded, e.g. *.azurewebsites.net (multiple can be specified as needed, just separate with a space).