### PR TITLE
Format decimal places

### DIFF
--- a/gov_uk_dashboards/formatting/round_and_add_prefix_and_suffix.py
+++ b/gov_uk_dashboards/formatting/round_and_add_prefix_and_suffix.py
@@ -1,10 +1,31 @@
 """
-Function to add a prefix and suffix to a number and also show the number of decimal places 
+Function to add a prefix and suffix to a number and also show the number of decimal places
 specified.
 """
+import math
 
 
-def round_and_add_prefix_and_suffix(value, decimal_places=None, prefix="", suffix=""):
+def round_and_add_prefix_and_suffix(
+    value, decimal_places=None, prefix="", suffix="", separator="-"
+):
+    """
+    Rounds a number to the specified number of decimal places, for example rounds 12 to 2dp as
+    12.00. Returns the formatted number as a string with and optional prefix and suffix.
+
+    Args:
+        value(float or int): number to format
+        prefix(str,optional): prefix to append to the start (e.g. £). Defaults to no prefix.
+        suffix(str,optional): suffix to append to the end (e.g. %). Defaults to no suffix.
+        decimal_places(int, optional): If set, rounds formatted number to that many d.p.
+            Defaults to None, which does not apply rounding.
+        separator(str,optional): If set, will be returned for a NaN or None passed as
+            value_to_format
+
+    Returns:
+        str: formatted number
+    """
+    if value is None or math.isnan(value):
+        return separator
     if decimal_places is not None:
         value = round(value, decimal_places)
         value = f"{value:.{decimal_places}f}"

--- a/gov_uk_dashboards/formatting/round_and_add_prefix_and_suffix.py
+++ b/gov_uk_dashboards/formatting/round_and_add_prefix_and_suffix.py
@@ -28,5 +28,6 @@ def round_and_add_prefix_and_suffix(
         return separator
     if decimal_places is not None:
         value = round(value, decimal_places)
-        value = f"{value:.{decimal_places}f}"
+        if decimal_places > 0:
+            value = f"{value:.{decimal_places}f}"
     return f"{prefix}{value}{suffix}"

--- a/gov_uk_dashboards/formatting/round_and_add_prefix_and_suffix.py
+++ b/gov_uk_dashboards/formatting/round_and_add_prefix_and_suffix.py
@@ -1,0 +1,11 @@
+"""
+Function to add a prefix and suffix to a number and also show the number of decimal places 
+specified.
+"""
+
+
+def round_and_add_prefix_and_suffix(value, decimal_places=None, prefix="", suffix=""):
+    if decimal_places is not None:
+        value = round(value, decimal_places)
+        value = f"{value:.{decimal_places}f}"
+    return f"{prefix}{value}{suffix}"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.10.0",
+    version="9.11.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),

--- a/tests/unit_tests/gov_uk_dashboards/formatting/test_round_and_add_prefix_and_suffix.py
+++ b/tests/unit_tests/gov_uk_dashboards/formatting/test_round_and_add_prefix_and_suffix.py
@@ -1,0 +1,34 @@
+from gov_uk_dashboards.formatting.round_and_add_prefix_and_suffix import (
+    round_and_add_prefix_and_suffix,
+)
+
+
+def test_round_and_add_prefix_and_suffix_returns_formatted_value():
+    assert round_and_add_prefix_and_suffix(1000000000) == "1000000000"
+    assert round_and_add_prefix_and_suffix(2100000000) == "2100000000"
+    assert round_and_add_prefix_and_suffix(45678987654, prefix="£") == "£45678987654"
+    assert round_and_add_prefix_and_suffix(569, suffix="%") == "569%"
+    assert (
+        round_and_add_prefix_and_suffix(342.2, prefix="£", suffix=" per person")
+        == "£342.2 per person"
+    )
+    assert (
+        round_and_add_prefix_and_suffix(
+            569, decimal_places=3, prefix="£", suffix=" per person"
+        )
+        == "£569.000 per person"
+    )
+    assert (
+        round_and_add_prefix_and_suffix(
+            342.2, decimal_places=4, prefix="£", suffix=" per person"
+        )
+        == "£342.2000 per person"
+    )
+    assert (
+        round_and_add_prefix_and_suffix(
+            float("NaN"), decimal_places=-1, separator="ABC"
+        )
+        == "ABC"
+    )
+    assert round_and_add_prefix_and_suffix(None, decimal_places=-1) == "-"
+    assert round_and_add_prefix_and_suffix(123, decimal_places=-1) == "120"


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Add "round_and_add_prefix_and_suffix" function and tests to round numbers to a given decimal place and includes trailing 0's.
eg. 1.2 to 2dp is 1.20
![image](https://github.com/communitiesuk/pkg_gov_uk_dashboards/assets/112866399/16d92db5-b0b8-4f93-963d-0d2f72d1c5e3)
