### PR TITLE
Removed padding from container

### DIFF
--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8064,9 +8064,9 @@ mark.expenditure {
 
 .grid-container-css {
   display: grid;
-  grid-template-columns: repeat(2, minmax(250px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   grid-auto-rows: 250px;
-  padding: 50px 300px;
+  padding: 50px 50px;
   gap: 75px 100px;
   align-items: stretch;
 }

--- a/gov_uk_dashboards/components/plotly/html_list.py
+++ b/gov_uk_dashboards/components/plotly/html_list.py
@@ -15,7 +15,6 @@ def html_list(
         classes.append("govuk-list--spaced")
 
     if numbered_list:
-
         classes.append("govuk-list--number")
         return html.Ol(li_items, className=" ".join(classes))
 

--- a/gov_uk_dashboards/lib/dap/dap_deployment.py
+++ b/gov_uk_dashboards/lib/dap/dap_deployment.py
@@ -17,7 +17,6 @@ def deploy_main_branch_to_pydash_test_environment(
     https://github.com/communitiesuk/plotly_dashboard_docs#dap-hosting-environment-pydash
     """
     with tempfile.TemporaryDirectory() as temporary_cloning_directory:
-
         pydash_repo = _clone_repo(
             url=dap_repo,
             into=temporary_cloning_directory,

--- a/gov_uk_dashboards/lib/http_headers.py
+++ b/gov_uk_dashboards/lib/http_headers.py
@@ -11,7 +11,6 @@ def setup_application_http_response_headers(dash_app: dash.Dash):
 
     @server.after_request
     def add_headers(response):
-
         content_security_policy = (
             "default-src 'self' 'unsafe-eval' 'unsafe-inline' data:"
         )

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1096,9 +1096,9 @@ mark.expenditure {
 
 .grid-container-css{
   display: grid;
-  grid-template-columns: repeat(2, minmax(250px, 1fr)); ;
+  grid-template-columns: repeat(2, 1fr); ;
   grid-auto-rows: 250px;
-  padding: 50px 300px;
+  padding: 50px 50px;
   gap: 75px 100px; 
   align-items: stretch;
 }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.12.0",
+    version="9.12.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
the padding was making the boxes overflow the gov UK container