### PR TITLE
Removed class that squished mobile navbar

### DIFF
--- a/gov_uk_dashboards/components/plotly/side_navbar.py
+++ b/gov_uk_dashboards/components/plotly/side_navbar.py
@@ -5,7 +5,7 @@ from dash import html, dcc
 
 
 def side_navbar(
-    links, identifier: Optional[str] = None, nav_id: Optional[str] = "navbar-section"
+    links, identifier: Optional[str] = None, nav_id: str = "navbar-section"
 ):
     """A navigation bar for switching between dashboards."""
     return html.Nav(
@@ -14,7 +14,7 @@ def side_navbar(
             id=identifier if identifier is not None else "",
             className="moj-side-navigation__list",
         ),
-        className="moj-side-navigation",
+        className="moj-side-navigation" if "mobile" not in nav_id else "",
         role="navigation",
         id=nav_id,
     )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.14.0",
+    version="9.13.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.13.0",
+    version="9.14.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
The mobile number was being squished to 20%, I've removed the class that caused that only for mobile, I've also removed the optional on the ID pass in, as I don't believe it makes any sense to pass in a None for the id