### PR TITLE
attach click event to links in nav bar so that it closes the nav bar …

### DIFF
--- a/gov_uk_dashboards/assets/mobile-nav.js
+++ b/gov_uk_dashboards/assets/mobile-nav.js
@@ -6,7 +6,7 @@ var mobileNav = null;
  * @type {boolean}
  */
 var isOpen = false;
-
+ 
 if (typeof attachEventToDash !== 'undefined') {
     attachEventToDash('mobile-menu-btn', 'click', function () {
         if (mobileNav === null) {
@@ -18,6 +18,21 @@ if (typeof attachEventToDash !== 'undefined') {
         mobileNav.style.display = isOpen ? 'none' : 'inline-block';
         isOpen = !isOpen;
     }, false)
+
+// attach click events that close the menu to links in the nav menu 
+var numberOfLinks = 8; // ideally get dynamically but document.querySelectorAll and trying to match id before attaching event to Dash didn't work.. 
+for (var i = 0; i < numberOfLinks; i++) {
+    var linkId = 'nav-bar-link-' + i + '-mobile';
+    attachEventToDash(linkId, 'click', function () {
+        if (mobileNav === null) {
+            mobileNav = document.getElementById('nav-section')
+            if (!mobileNav) {
+                return;
+            }
+        }
+        mobileNav.style.display = 'none';
+        isOpen = false;
+        }, false);
 }
 
 /**
@@ -46,4 +61,4 @@ window.addEventListener(
             }
         }
     }, 150)
-);
+);}

--- a/gov_uk_dashboards/assets/mobile-nav.js
+++ b/gov_uk_dashboards/assets/mobile-nav.js
@@ -20,8 +20,7 @@ if (typeof attachEventToDash !== 'undefined') {
     }, false)
 
 // attach click events that close the menu to links in the nav menu 
-var numberOfLinks = 8; // ideally get dynamically but document.querySelectorAll and trying to match id before attaching event to Dash didn't work.. 
-for (var i = 0; i < numberOfLinks; i++) {
+for (var i = 0; i < getNumberOfLinks(); i++) {
     var linkId = 'nav-bar-link-' + i + '-mobile';
     attachEventToDash(linkId, 'click', function () {
         if (mobileNav === null) {
@@ -41,6 +40,11 @@ for (var i = 0; i < numberOfLinks; i++) {
  * @param {number} time
  * @returns
  */
+
+function getNumberOfLinks() {
+    return document.getElementById('mobile-navigation-items').getElementsByTagName('A')
+}
+
 function debounce(func, time) {
     var time = time || 100; // 100 by default if no param
     var timer;

--- a/gov_uk_dashboards/assets/mobile-nav.js
+++ b/gov_uk_dashboards/assets/mobile-nav.js
@@ -19,30 +19,27 @@ if (typeof attachEventToDash !== 'undefined') {
         isOpen = !isOpen;
     }, false)
 
-// attach click events that close the menu to links in the nav menu 
-for (var i = 0; i < getNumberOfLinks(); i++) {
-    var linkId = 'nav-bar-link-' + i + '-mobile';
-    attachEventToDash(linkId, 'click', function () {
-        if (mobileNav === null) {
-            mobileNav = document.getElementById('nav-section')
-            if (!mobileNav) {
-                return;
+// Wait until the 'mobile-navigation-items' element is loaded
+var checkExist = setInterval(function() {
+    var element = document.getElementById('mobile-navigation-items');
+    if (element) {
+        clearInterval(checkExist);
+        var links = element.getElementsByTagName('a');
+        console.log(links)
+        attachEventsToLinks(links);
+    }
+}, 100);
+
+function attachEventsToLinks(links) {
+    for (var i = 0; i < links.length; i++) {
+        var link = links[i];
+        link.addEventListener('click', function() {
+            var mobileNav =document.getElementById('nav-section');
+            if (mobileNav) {
+                mobileNav.style.display = 'none';
             }
-        }
-        mobileNav.style.display = 'none';
-        isOpen = false;
         }, false);
-}
-
-/**
- *
- * @param {function} func
- * @param {number} time
- * @returns
- */
-
-function getNumberOfLinks() {
-    return document.getElementById('mobile-navigation-items').getElementsByTagName('A')
+    }
 }
 
 function debounce(func, time) {

--- a/gov_uk_dashboards/assets/mobile-nav.js
+++ b/gov_uk_dashboards/assets/mobile-nav.js
@@ -37,6 +37,7 @@ function attachEventsToLinks(links) {
             var mobileNav =document.getElementById('nav-section');
             if (mobileNav) {
                 mobileNav.style.display = 'none';
+                isOpen = false;
             }
         }, false);
     }

--- a/gov_uk_dashboards/assets/mobile-nav.js
+++ b/gov_uk_dashboards/assets/mobile-nav.js
@@ -25,7 +25,6 @@ var checkExist = setInterval(function() {
     if (element) {
         clearInterval(checkExist);
         var links = element.getElementsByTagName('a');
-        console.log(links)
         attachEventsToLinks(links);
     }
 }, 100);

--- a/gov_uk_dashboards/components/plotly/side_navbar.py
+++ b/gov_uk_dashboards/components/plotly/side_navbar.py
@@ -20,15 +20,16 @@ def side_navbar(
     )
 
 
-def side_navbar_link(text, href):
+def side_navbar_link(text, href, link_id):
     """A link to another dashboard"""
     return html.Li(
         dcc.Link(text, href=href, className="govuk-link govuk-link--no-visited-state"),
         className="moj-side-navigation__item govuk-!-margin-bottom-1",
+        id=link_id,
     )
 
 
-def side_navbar_link_active(text, href):
+def side_navbar_link_active(text, href, link_id):
     """
     A link to another dashboard that appears highlighted, suggesting to the user that they are
     already viewing the linked dashboard.
@@ -39,4 +40,5 @@ def side_navbar_link_active(text, href):
             "moj-side-navigation__item moj-side-navigation__item--active "
             "govuk-!-margin-bottom-1"
         ),
+        id=link_id,
     )

--- a/gov_uk_dashboards/components/plotly/side_navbar.py
+++ b/gov_uk_dashboards/components/plotly/side_navbar.py
@@ -20,16 +20,15 @@ def side_navbar(
     )
 
 
-def side_navbar_link(text, href, link_id):
+def side_navbar_link(text, href):
     """A link to another dashboard"""
     return html.Li(
         dcc.Link(text, href=href, className="govuk-link govuk-link--no-visited-state"),
         className="moj-side-navigation__item govuk-!-margin-bottom-1",
-        id=link_id,
     )
 
 
-def side_navbar_link_active(text, href, link_id):
+def side_navbar_link_active(text, href):
     """
     A link to another dashboard that appears highlighted, suggesting to the user that they are
     already viewing the linked dashboard.
@@ -40,5 +39,4 @@ def side_navbar_link_active(text, href, link_id):
             "moj-side-navigation__item moj-side-navigation__item--active "
             "govuk-!-margin-bottom-1"
         ),
-        id=link_id,
     )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.14.0",
+    version="9.13.5",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.13.4",
+    version="9.14.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
https://trello.com/c/obS5d69m
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
 - Make the navbar links close the menu when on a mobile device 
 - Also changes to add ids to links in the LG dashboard

