### PR TITLE
Add allow_double_click parameter to captioned_figure

### DIFF
--- a/gov_uk_dashboards/components/plotly/captioned_figure.py
+++ b/gov_uk_dashboards/components/plotly/captioned_figure.py
@@ -14,6 +14,7 @@ def captioned_figure(
     *,
     graph_style: Optional[dict[str, Any]] = None,
     desktop_only: bool = False,
+    allow_double_click: bool = True,
 ):
     """
     Return figure with attached caption that can be read by a screen reader.
@@ -33,6 +34,8 @@ def captioned_figure(
             Defaults to None.
         desktop_only (bool, optional): Whether the figure should be replaced with
             the caption when viewed on mobile. Defaults to False.
+        allow_double_click (bool, optional): Whether the figure allows double click action to
+            zoom out.
 
     Returns:
         dash.html.Figure: Figure html element containing the graph and its caption.
@@ -51,7 +54,7 @@ def captioned_figure(
                     responsive=True,
                     figure=figure,
                     style=graph_style,
-                    config={"displayModeBar": False},
+                    config={"displayModeBar": False, "doubleClick": allow_double_click},
                 ),
                 className="jitter-desktop-only" if desktop_only else "",
                 **{"role": "img", "aria-labelledby": f"{figure_name}-caption"},

--- a/gov_uk_dashboards/components/plotly/captioned_figure.py
+++ b/gov_uk_dashboards/components/plotly/captioned_figure.py
@@ -14,7 +14,7 @@ def captioned_figure(
     *,
     graph_style: Optional[dict[str, Any]] = None,
     desktop_only: bool = False,
-    allow_double_click: bool = True,
+    double_click_attribute: Union[str, bool] = True,
 ):
     """
     Return figure with attached caption that can be read by a screen reader.
@@ -34,8 +34,8 @@ def captioned_figure(
             Defaults to None.
         desktop_only (bool, optional): Whether the figure should be replaced with
             the caption when viewed on mobile. Defaults to False.
-        allow_double_click (bool, optional): Whether the figure allows double click action to
-            zoom out.
+        double_click_attribute (Union[str, bool]): Set the doubleClick attribute, which controls
+            the response when a user double clicks on the plot. Defaults to True.
 
     Returns:
         dash.html.Figure: Figure html element containing the graph and its caption.
@@ -54,7 +54,10 @@ def captioned_figure(
                     responsive=True,
                     figure=figure,
                     style=graph_style,
-                    config={"displayModeBar": False, "doubleClick": allow_double_click},
+                    config={
+                        "displayModeBar": False,
+                        "doubleClick": double_click_attribute,
+                    },
                 ),
                 className="jitter-desktop-only" if desktop_only else "",
                 **{"role": "img", "aria-labelledby": f"{figure_name}-caption"},

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.13.7",
+    version="9.13.8",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
Link to trello ticket https://trello.com/c/9SFiDOYa
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Remove ability to double click on jitter plots to zoom/autoscale
