### PR TITLE
reset filter button has role type button rather than link

### DIFF
--- a/gov_uk_dashboards/components/plotly/apply_and_reset_filters_buttons.py
+++ b/gov_uk_dashboards/components/plotly/apply_and_reset_filters_buttons.py
@@ -12,7 +12,7 @@ def apply_and_reset_filters_buttons():
                 "Reset filters",
                 href="?",
                 className="govuk-link govuk-body",
-                role="button"
+                role="button",
             ),
             html.Button(
                 "Apply filters",

--- a/gov_uk_dashboards/components/plotly/apply_and_reset_filters_buttons.py
+++ b/gov_uk_dashboards/components/plotly/apply_and_reset_filters_buttons.py
@@ -12,6 +12,7 @@ def apply_and_reset_filters_buttons():
                 "Reset filters",
                 href="?",
                 className="govuk-link govuk-body",
+                role="button"
             ),
             html.Button(
                 "Apply filters",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.16.2",
+    version="9.16.3",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
https://trello.com/c/ef5bD5bN/1896-bug-reset-filters-link-changed-to-button
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Fix bug - Reset filters was incorrectly reported as a link to screen reader users. It is now reported as a button.