### PR TITLE
Fix pandas warning

### DIFF
--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -75,7 +75,7 @@ def table_from_dataframe(
         html.Tbody(
             [
                 html.Tr(
-                    [html.Th(row[0], scope="row", className="govuk-table__header")]
+                    [html.Th(row.iloc[0], scope="row", className="govuk-table__header")]
                     + [html.Td(cell, className="govuk-table__cell") for cell in row[1:]]
                 )
                 if first_column_is_header and index != last_row_index

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.16.3",
+    version="9.16.4",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Previously getting the following warning.  The suggested change fixes it:
``` 
...gov_uk_dashboards\components\plotly\table.py:
78: FutureWarning:

Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as l
abels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
```
Patch to 9.16.4