### PR TITLE
Add analysis function colours

### DIFF
--- a/gov_uk_dashboards/colours.py
+++ b/gov_uk_dashboards/colours.py
@@ -58,3 +58,25 @@ class ONSAccessibleColours(Enum):
     MAROON = "#871a5b"
     # LIGHT_BLUE = "#27a0cc"
     ORANGE = "#f47738"
+
+
+class AFAccessibleColours(Enum):
+    """Analysis Function colour palettes taken from
+    https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/
+    """
+
+    # categorical colours to be used separately or from CATEGORICAL list - ideally only use first 4
+    DARK_BLUE = "#12436D"
+    TURQUOISE = "#28A197"
+    DARK_PINK = "#801650"
+    ORANGE = "#F46A25"
+    DARK_GREY = "#3D3D3D"
+    LIGHT_PURPLE = "#A285D1"
+
+    CATEGORICAL = [DARK_BLUE, TURQUOISE, DARK_PINK, ORANGE, DARK_GREY, LIGHT_PURPLE]
+
+    # three shades of blue from dark to light to use for sequential data
+    BLUE_SEQUENTIAL = ["#12436D", "#2073BC", "#6BACE6"]
+
+    # focus palette, use dark blue (first element) for focus data and grey for the rest
+    FOCUS_PALETTE = ["#12436D", "#BFBFBF"]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.26.0",
+    version="9.27.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [NA] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Add the three analyis function colour palettes to the colours enums