### PR TITLE
Add grid layout and box container layout classes

### DIFF
--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8199,3 +8199,24 @@ mark.expenditure {
   display: inline-block;
   vertical-align: middle;
 }
+
+.three_column_grid_layout {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px 100px;
+}
+
+.two_column_grid_layout {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px 100px;
+}
+
+.box_container_layout {
+  background-color: #f3f2f1;
+  padding: 20px 20px 10px 20px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1238,3 +1238,27 @@ mark.expenditure {
   display: inline-block;
   vertical-align: middle;
 }
+
+.three_column_grid_layout {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px 100px;
+}
+
+.two_column_grid_layout {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px 100px;
+}
+
+.box_container_layout {
+  // GOV UK colours LIGHT_GREY
+  background-color: #f3f2f1;
+  padding: 20px 20px 10px 20px;
+  margin-bottom: 20px;
+  display: flex;
+  // Stack children vertically
+  flex-direction: column; 
+  // Stretch children to match the width of the container
+  align-items: stretch;  
+} 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.33.0",
+    version="9.34.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [x] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Add 3 new classes for creating grid layouts & box container layout 

- three_column_grid_layout 
- two_column_grid_layout 
- box_container_layout 