### PR TITLE
Add css for homepage

### DIFF
--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8083,7 +8083,7 @@ mark.expenditure {
 }
 
 @media (max-width: 600px) {
-  .grid-container-css, .grid-container-home-page {
+  .grid-container-css {
     grid-template-columns: 1fr;
   }
 }
@@ -8288,4 +8288,10 @@ mark.expenditure {
   padding: 20px 0px;
   gap: 20px 100px;
   align-items: stretch;
+}
+
+@media (max-width: 600px) {
+  .grid-container-home-page {
+    grid-template-columns: 1fr;
+  }
 }

--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8083,7 +8083,7 @@ mark.expenditure {
 }
 
 @media (max-width: 600px) {
-  .grid-container-css {
+  .grid-container-css, .grid-container-home-page {
     grid-template-columns: 1fr;
   }
 }
@@ -8254,4 +8254,38 @@ mark.expenditure {
 .fix-width {
   width: 197px;
   display: inline-block;
+}
+
+.grid-labels {
+  display: flex;
+  align-items: center;
+  width: calc(100% - 100px);
+  height: 100px;
+  padding: 0px 10px;
+}
+
+.grid-icons-img {
+  height: 64px;
+  width: 64px;
+  padding: 18px;
+}
+
+.grid-item-home-page {
+  background-color: #1d70b8;
+  color: white;
+  text-align: left;
+  display: flex;
+  box-sizing: border-box;
+  overflow: hidden;
+  font-weight: bold;
+  height: 100px;
+}
+
+.grid-container-home-page {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-auto-rows: 100px;
+  padding: 20px 0px;
+  gap: 20px 100px;
+  align-items: stretch;
 }

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1115,7 +1115,7 @@ mark.expenditure {
 }
 
 @media (max-width: 600px) {
-  .grid-container-css {
+  .grid-container-css, .grid-container-home-page {
     grid-template-columns: 1fr; 
   }
 }
@@ -1298,3 +1298,37 @@ mark.expenditure {
     display: inline-block;
     // width of 197px determined from OFFICIAL-SENSITIVE in protective marking to ensure app title is always central in header
 }
+
+.grid-labels {
+  display: flex;
+  align-items: center;
+  width: calc(100% - 100px);
+  height: 100px;
+  padding: 0px 10px;
+}
+
+.grid-icons-img {
+  height:64px;
+  width:64px;
+  padding: 18px;
+  }
+
+.grid-item-home-page {
+    background-color: #1d70b8;
+    color: white;
+    text-align: left;
+    display: flex;
+    box-sizing: border-box;
+    overflow: hidden;
+    font-weight: bold;
+    height: 100px;
+  }
+
+.grid-container-home-page{
+    display: grid;
+    grid-template-columns: repeat(2, 1fr); ;
+    grid-auto-rows: 100px;
+    padding: 20px 0px;
+    gap: 20px 100px; 
+    align-items: stretch;
+  }

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1115,7 +1115,7 @@ mark.expenditure {
 }
 
 @media (max-width: 600px) {
-  .grid-container-css, .grid-container-home-page {
+  .grid-container-css {
     grid-template-columns: 1fr; 
   }
 }
@@ -1332,3 +1332,9 @@ mark.expenditure {
     gap: 20px 100px; 
     align-items: stretch;
   }
+
+@media (max-width: 600px) {
+  .grid-container-home-page {
+    grid-template-columns: 1fr; 
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.43.0",
+    version="9.44.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.42.0",
+    version="9.43.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="9.44.0",
+    version="9.43.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [N/A] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Add CSS classes for use on homepage buttons