### PR TITLE
Optimise for mobile devices and smaller screens

### DIFF
--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -3366,17 +3366,12 @@ x:-moz-any-link {
   display: inline-block;
   min-width: 125px;
   padding-top: 112px;
-  background-image: url("/assets/images/govuk-crest.png");
+  background-image: url("/assets/images/govuk-crest.svg");
   background-repeat: no-repeat;
   background-position: 50% 0%;
   background-size: 125px 102px;
   text-align: center;
   white-space: nowrap;
-}
-@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
-  .govuk-footer__copyright-logo {
-    background-image: url("/assets/images/govuk-crest-2x.png");
-  }
 }
 
 .govuk-footer__inline-list {
@@ -8220,7 +8215,7 @@ mark.expenditure {
 .two_column_grid_layout_second_width_twice_first {
   display: grid;
   grid-template-columns: 1fr 2fr;
-  gap: 20px 100px;
+  gap: 20px 7%;
 }
 
 @media (max-width: 600px) {
@@ -8231,9 +8226,14 @@ mark.expenditure {
 .two_column_grid_layout_first_width_twice_second {
   display: grid;
   grid-template-columns: 2fr 1fr;
-  gap: 20px 100px;
+  gap: 20px 7%;
 }
 
+@media (max-width: 600px) {
+  .two_column_grid_layout_first_width_twice_second {
+    grid-template-columns: 1fr;
+  }
+}
 .box_container_layout {
   background-color: #f3f2f1;
   padding: 20px 20px 10px 20px;
@@ -8304,4 +8304,16 @@ mark.expenditure {
   .grid-container-home-page {
     grid-template-columns: 1fr;
   }
+}
+.context-card-grid-item {
+  background-color: #f3f2f1;
+  padding: 20px 20px 10px 20px;
+  margin-bottom: 20px;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  box-sizing: border-box;
+  overflow: hidden;
 }

--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -3366,12 +3366,17 @@ x:-moz-any-link {
   display: inline-block;
   min-width: 125px;
   padding-top: 112px;
-  background-image: url("/assets/images/govuk-crest.svg");
+  background-image: url("/assets/images/govuk-crest.png");
   background-repeat: no-repeat;
   background-position: 50% 0%;
   background-size: 125px 102px;
   text-align: center;
   white-space: nowrap;
+}
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
+  .govuk-footer__copyright-logo {
+    background-image: url("/assets/images/govuk-crest-2x.png");
+  }
 }
 
 .govuk-footer__inline-list {
@@ -8197,6 +8202,11 @@ mark.expenditure {
   gap: 20px 100px;
 }
 
+@media (max-width: 600px) {
+  .three_column_grid_layout {
+    grid-template-columns: 1fr;
+  }
+}
 .two_column_grid_layout {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8198,7 +8198,7 @@ mark.expenditure {
 .three_column_grid_layout {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 20px 100px;
+  gap: 20px 7%;
 }
 
 @media (max-width: 600px) {

--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8168,7 +8168,6 @@ mark.expenditure {
 
 .changed-from-box-formatting {
   margin-top: 2px !important;
-  white-space: nowrap !important;
   background-repeat: no-repeat !important;
   background-position: 6px !important;
 }

--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8209,11 +8209,11 @@ mark.expenditure {
 .two_column_grid_layout {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 20px 100px;
+  gap: 20px 7%;
 }
 
 @media (max-width: 600px) {
-  .three_column_grid_layout {
+  .two_column_grid_layout {
     grid-template-columns: 1fr;
   }
 }

--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8212,6 +8212,11 @@ mark.expenditure {
   gap: 20px 100px;
 }
 
+@media (max-width: 600px) {
+  .three_column_grid_layout {
+    grid-template-columns: 1fr;
+  }
+}
 .two_column_grid_layout_second_width_twice_first {
   display: grid;
   grid-template-columns: 1fr 2fr;

--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8223,6 +8223,11 @@ mark.expenditure {
   gap: 20px 100px;
 }
 
+@media (max-width: 600px) {
+  .two_column_grid_layout_second_width_twice_first {
+    grid-template-columns: 1fr;
+  }
+}
 .two_column_grid_layout_first_width_twice_second {
   display: grid;
   grid-template-columns: 2fr 1fr;

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -3,6 +3,7 @@ from typing import Optional
 from pandas import DataFrame
 from dash import html, dcc
 from gov_uk_dashboards.components.plotly.card import card
+from gov_uk_dashboards.components.plotly.row_component import row_component
 
 
 def table_from_dataframe(
@@ -227,13 +228,17 @@ def table_from_polars_dataframe(
         )
     )
 
-    return card(
-        html.Table(
-            table_contents,
-            className="govuk-table table-header-cell-top-padding",
-            id=table_id,
-            role="table",
-            **table_properties,
-        ),
-        amend_style={"padding": "0px"},
-    )
+    return row_component(
+    card(row_component(card(
+    html.Table(
+        table_contents,
+        className="govuk-table table-header-cell-top-padding",
+        id=table_id,
+        role="table",
+        **table_properties,
+    ),
+    amend_style={"padding": "0px"}
+),horizontal_scroll=True)),
+    horizontal_scroll=True,
+)
+

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -229,16 +229,20 @@ def table_from_polars_dataframe(
     )
 
     return row_component(
-    card(row_component(card(
-    html.Table(
-        table_contents,
-        className="govuk-table table-header-cell-top-padding",
-        id=table_id,
-        role="table",
-        **table_properties,
-    ),
-    amend_style={"padding": "0px"}
-),horizontal_scroll=True)),
-    horizontal_scroll=True,
-)
-
+        card(
+            row_component(
+                card(
+                    html.Table(
+                        table_contents,
+                        className="govuk-table table-header-cell-top-padding",
+                        id=table_id,
+                        role="table",
+                        **table_properties,
+                    ),
+                    amend_style={"padding": "0px"},
+                ),
+                horizontal_scroll=True,
+            )
+        ),
+        horizontal_scroll=True,
+    )

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1207,7 +1207,7 @@ mark.expenditure {
 
 .changed-from-box-formatting {
   margin-top: 2px!important;
-  white-space: nowrap!important;
+  // white-space: nowrap!important;
   background-repeat: no-repeat!important;
   background-position: 6px!important
 }

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1241,6 +1241,12 @@ mark.expenditure {
   gap: 20px 100px;
 }
 
+@media (max-width: 600px) {
+  .three_column_grid_layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 .two_column_grid_layout {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1253,6 +1253,12 @@ mark.expenditure {
   gap: 20px 100px;
 }
 
+@media (max-width: 600px) {
+  .three_column_grid_layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 .two_column_grid_layout_second_width_twice_first {
   display: grid;
   grid-template-columns: 1fr 2fr;

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1250,11 +1250,11 @@ mark.expenditure {
 .two_column_grid_layout {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 20px 100px;
+  gap: 20px 7%;
 }
 
 @media (max-width: 600px) {
-  .three_column_grid_layout {
+  .two_column_grid_layout {
     grid-template-columns: 1fr;
   }
 }

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1265,6 +1265,12 @@ mark.expenditure {
   gap: 20px 100px;
 }
 
+@media (max-width: 600px) {
+  .two_column_grid_layout_second_width_twice_first {
+    grid-template-columns: 1fr;
+  }
+}
+
 .two_column_grid_layout_first_width_twice_second {
   display: grid;
   grid-template-columns: 2fr 1fr;

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1262,7 +1262,7 @@ mark.expenditure {
 .two_column_grid_layout_second_width_twice_first {
   display: grid;
   grid-template-columns: 1fr 2fr;
-  gap: 20px 100px;
+  gap: 20px 7%;
 }
 
 @media (max-width: 600px) {
@@ -1274,7 +1274,13 @@ mark.expenditure {
 .two_column_grid_layout_first_width_twice_second {
   display: grid;
   grid-template-columns: 2fr 1fr;
-  gap: 20px 100px;
+  gap: 20px 7%;
+}
+
+@media (max-width: 600px) {
+  .two_column_grid_layout_first_width_twice_second {
+    grid-template-columns: 1fr;
+  }
 }
 
 .box_container_layout {
@@ -1351,4 +1357,17 @@ mark.expenditure {
   .grid-container-home-page {
     grid-template-columns: 1fr; 
   }
+}
+
+.context-card-grid-item{
+  background-color: #f3f2f1;
+    padding: 20px 20px 10px 20px;
+    margin-bottom: 20px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    box-sizing: border-box;
+    overflow: hidden;
 }

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1207,7 +1207,6 @@ mark.expenditure {
 
 .changed-from-box-formatting {
   margin-top: 2px!important;
-  // white-space: nowrap!important;
   background-repeat: no-repeat!important;
   background-position: 6px!important
 }

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1238,7 +1238,7 @@ mark.expenditure {
 .three_column_grid_layout {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 20px 100px;
+  gap: 20px 7%;
 }
 
 @media (max-width: 600px) {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="12.0.0",
+    version="12.0.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="12.0.1",
+    version="12.1.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [x] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
Optimise dashboard for smaller screens & mobile devices:
•	For grid layout classes add css media rule when width is less than 600px so that the grid only has 1 column
•	Make horizontal gap % so that it is in proportion with width
•	Add new context-card-grid-item class 
•	Update table component so that it horizontally scrolls and does not overflow 