### PR TITLE
context card content anchored to top of container

### DIFF
--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -8311,7 +8311,6 @@ mark.expenditure {
   margin-bottom: 20px;
   text-align: center;
   display: flex;
-  justify-content: center;
   align-items: center;
   flex-direction: column;
   box-sizing: border-box;

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -235,14 +235,16 @@ def table_from_polars_dataframe(
         card(
             row_component(
                 card(
-                    html.Table(
-                        table_contents,
-                        className="govuk-table table-header-cell-top-padding",
-                        id=table_id,
-                        role="table",
-                        **table_properties,
-                    ),
-                    paragraph(table_footer) if table_footer else None,
+                    [
+                        html.Table(
+                            table_contents,
+                            className="govuk-table table-header-cell-top-padding",
+                            id=table_id,
+                            role="table",
+                            **table_properties,
+                        ),
+                        paragraph(table_footer) if table_footer else None,
+                    ],
                     amend_style={"padding": "0px"},
                 ),
                 horizontal_scroll=True,

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -3,6 +3,7 @@ from typing import Optional
 from pandas import DataFrame
 from dash import html, dcc
 from gov_uk_dashboards.components.plotly.card import card
+from gov_uk_dashboards.components.plotly.paragraph import paragraph
 from gov_uk_dashboards.components.plotly.row_component import row_component
 
 
@@ -108,6 +109,7 @@ def table_from_polars_dataframe(
     last_row_unbolded: bool = False,
     format_column_headers_as_markdown: bool = False,
     table_id: str = "table",
+    table_footer: str = None,
     column_widths: Optional[list[str]] = None,
     **table_properties,
 ):  # pylint: disable=too-many-arguments
@@ -131,6 +133,7 @@ def table_from_polars_dataframe(
         format_column_headers_as_markdown: (bool, optional): Sets if the column headers should
             be formatted as markdown. Defaults to False.
         table_id: (str, optional): ID for the table Defaults to "table".
+        table_footer: (str, optional): Text to display underneath table as footer.
         column_widths: (list[str], optional): Determines width of table columns. Format as a list,
             "x%". List must be same length as dataframe columns. Defaults to None.
         **table_properties: Any additional arguments for the html.Table object,
@@ -239,6 +242,7 @@ def table_from_polars_dataframe(
                         role="table",
                         **table_properties,
                     ),
+                    paragraph(table_footer) if table_footer else None,
                     amend_style={"padding": "0px"},
                 ),
                 horizontal_scroll=True,

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1364,7 +1364,6 @@ mark.expenditure {
     margin-bottom: 20px;
     text-align: center;
     display: flex;
-    justify-content: center;
     align-items: center;
     flex-direction: column;
     box-sizing: border-box;

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="12.1.0",
+    version="12.1.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:

- context card content anchored to top of container by removing justify-content: centre from context-card-grid-item
- added footer option to table from polars df