### PR TITLE
Scrolly table - fixed headers

### DIFF
--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -4,6 +4,7 @@ from pandas import DataFrame
 from dash import html, dcc
 from gov_uk_dashboards.components.plotly.card import card
 from gov_uk_dashboards.components.plotly.paragraph import paragraph
+
 # from gov_uk_dashboards.components.plotly.row_component import row_component
 
 

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -4,7 +4,7 @@ from pandas import DataFrame
 from dash import html, dcc
 from gov_uk_dashboards.components.plotly.card import card
 from gov_uk_dashboards.components.plotly.paragraph import paragraph
-from gov_uk_dashboards.components.plotly.row_component import row_component
+# from gov_uk_dashboards.components.plotly.row_component import row_component
 
 
 def table_from_dataframe(

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -259,11 +259,9 @@ def table_from_polars_dataframe(
             className="govuk-table__body",
         )
     )
-
-    return row_component(
-        card(
-            row_component(
-                card(
+    
+    # commented below out as prevents sticky header, although now not optimised for mobile devices
+    return card(
                     [
                         html.Table(
                             table_contents,
@@ -275,9 +273,26 @@ def table_from_polars_dataframe(
                         paragraph(table_footer) if table_footer else None,
                     ],
                     amend_style={"padding": "0px"},
-                ),
-                horizontal_scroll=True,
-            )
-        ),
-        horizontal_scroll=True,
-    )
+                )
+
+    # return row_component(
+    #     card(
+    #         row_component(
+    #             card(
+    #                 [
+    #                     html.Table(
+    #                         table_contents,
+    #                         className="govuk-table table-header-cell-top-padding",
+    #                         id=table_id,
+    #                         role="table",
+    #                         **table_properties,
+    #                     ),
+    #                     paragraph(table_footer) if table_footer else None,
+    #                 ],
+    #                 amend_style={"padding": "0px"},
+    #             ),
+    #             horizontal_scroll=True,
+    #         )
+    #     ),
+    #     horizontal_scroll=True,
+    # )

--- a/gov_uk_dashboards/components/plotly/table.py
+++ b/gov_uk_dashboards/components/plotly/table.py
@@ -259,21 +259,21 @@ def table_from_polars_dataframe(
             className="govuk-table__body",
         )
     )
-    
+
     # commented below out as prevents sticky header, although now not optimised for mobile devices
     return card(
-                    [
-                        html.Table(
-                            table_contents,
-                            className="govuk-table table-header-cell-top-padding",
-                            id=table_id,
-                            role="table",
-                            **table_properties,
-                        ),
-                        paragraph(table_footer) if table_footer else None,
-                    ],
-                    amend_style={"padding": "0px"},
-                )
+        [
+            html.Table(
+                table_contents,
+                className="govuk-table table-header-cell-top-padding",
+                id=table_id,
+                role="table",
+                **table_properties,
+            ),
+            paragraph(table_footer) if table_footer else None,
+        ],
+        amend_style={"padding": "0px"},
+    )
 
     # return row_component(
     #     card(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="13.0.",
+    version="13.0.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="12.3.4",
+    version="13.0.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Tables now have fixed header when scrolling, though now not compatible on mobiles - follow up needed