### PR TITLE
Add total to bar chart hover

### DIFF
--- a/gov_uk_dashboards/components/plotly/stacked_barchart.py
+++ b/gov_uk_dashboards/components/plotly/stacked_barchart.py
@@ -67,6 +67,7 @@ class StackedBarChart:
         hover_distance: Optional[int] = 1,
         download_chart_button_id: Optional[str] = None,
         download_data_button_id: Optional[str] = None,
+        total_trace_name: Optional[str] = None
     ):
         """Initializes the StackedBarChart instance.
         To display the chart, call the `get_stacked_bar_chart()` method.
@@ -90,6 +91,9 @@ class StackedBarChart:
                 if applicable. Defaults to None.
             download_data_button_id (Optional[str], optional): ID for the data download button, if
                 applicable. Defaults to None.
+            total_trace_name (Optional[str], optional): Name for an optional total to be added to 
+                bottom of hover text, must be in MEASURE column of df, line_trace_name will display 
+                in legend. Defaults to None.
         """
         self.title_data = title_data
         self.y_axis_column = y_axis_column
@@ -104,6 +108,7 @@ class StackedBarChart:
         self.hover_distance = hover_distance
         self.download_chart_button_id = download_chart_button_id
         self.download_data_button_id = download_data_button_id
+        self.total_trace_name = total_trace_name
         self.fig = self.create_stacked_bar_chart()
 
     def get_stacked_bar_chart(self) -> html.Div:
@@ -173,6 +178,23 @@ class StackedBarChart:
         # pylint: disable=too-many-locals
 
         fig = go.Figure()
+        if self.total_trace_name is not None:
+            df = self.df.filter(pl.col(MEASURE) == self.total_trace_name)
+
+            fig.add_trace(
+                go.Scatter(
+                    x=df[self.x_axis_column],
+                    y=df[self.y_axis_column],
+                    customdata=self._get_custom_data(self.total_trace_name, df),
+                    mode="markers",
+                    marker=dict(color="white",opacity=0),
+                    name=self.total_trace_name + LEGEND_SPACING,
+                    hovertemplate="Total income: %{customdata[0]}<extra></extra>",
+                    showlegend=False,
+                    hoverinfo="skip",
+                    legendrank=1,
+                )
+            )
         colour_list = (
             AFAccessibleColours.CATEGORICAL.value
             if len(self.trace_name_list) != 2

--- a/gov_uk_dashboards/components/plotly/stacked_barchart.py
+++ b/gov_uk_dashboards/components/plotly/stacked_barchart.py
@@ -67,7 +67,7 @@ class StackedBarChart:
         hover_distance: Optional[int] = 1,
         download_chart_button_id: Optional[str] = None,
         download_data_button_id: Optional[str] = None,
-        total_trace_name: Optional[str] = None
+        total_trace_name: Optional[str] = None,
     ):
         """Initializes the StackedBarChart instance.
         To display the chart, call the `get_stacked_bar_chart()` method.
@@ -91,8 +91,8 @@ class StackedBarChart:
                 if applicable. Defaults to None.
             download_data_button_id (Optional[str], optional): ID for the data download button, if
                 applicable. Defaults to None.
-            total_trace_name (Optional[str], optional): Name for an optional total to be added to 
-                bottom of hover text, must be in MEASURE column of df, line_trace_name will display 
+            total_trace_name (Optional[str], optional): Name for an optional total to be added to
+                bottom of hover text, must be in MEASURE column of df, line_trace_name will display
                 in legend. Defaults to None.
         """
         self.title_data = title_data
@@ -187,7 +187,7 @@ class StackedBarChart:
                     y=df[self.y_axis_column],
                     customdata=self._get_custom_data(self.total_trace_name, df),
                     mode="markers",
-                    marker=dict(color="white",opacity=0),
+                    marker={"color": 'white', "opacity": 0},
                     name=self.total_trace_name + LEGEND_SPACING,
                     hovertemplate="Total income: %{customdata[0]}<extra></extra>",
                     showlegend=False,

--- a/gov_uk_dashboards/components/plotly/stacked_barchart.py
+++ b/gov_uk_dashboards/components/plotly/stacked_barchart.py
@@ -187,7 +187,7 @@ class StackedBarChart:
                     y=df[self.y_axis_column],
                     customdata=self._get_custom_data(self.total_trace_name, df),
                     mode="markers",
-                    marker={"color": 'white', "opacity": 0},
+                    marker={"color": "white", "opacity": 0},
                     name=self.total_trace_name + LEGEND_SPACING,
                     hovertemplate="Total income: %{customdata[0]}<extra></extra>",
                     showlegend=False,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="19.0.0",
+    version="19.1.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
https://trello.com/c/o1uLd5Pj/4023-m-1-x-15-day-15-dev-days-csp-stacked-bar-charts-has-unified-hover-and-ability-to-download-%F0%9F%94%B5

## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [x] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:

Add option to add total to hovertext