### PR TITLE
adjust padding for colorbar title on leaflet choropleth map

### DIFF
--- a/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
+++ b/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
@@ -267,11 +267,12 @@ class LeafletChoroplethMap:
     def _get_colorbar_title(self):
         if self.color_scale_is_discrete:
             return None
+        top = "70px" if self.enable_zoom == False else "140px"
         return html.Div(
             self.hover_text_columns[0],
             style={
                 "position": "absolute",
-                "top": "70px",  # Adjusted to place above the colorbar
+                "top": top,  # Adjusted to place above the colorbar
                 "left": "10px",  # Align with the left side of the colorbar
                 "background": "white",
                 "padding": "2px 6px",

--- a/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
+++ b/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
@@ -267,7 +267,7 @@ class LeafletChoroplethMap:
     def _get_colorbar_title(self):
         if self.color_scale_is_discrete:
             return None
-        top = "70px" if self.enable_zoom == False else "140px"
+        top = "70px" if self.enable_zoom is False else "140px"
         return html.Div(
             self.hover_text_columns[0],
             style={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="22.0.0",
+    version="22.1.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [N/A] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:
So that colorbar title is positioned correctly when using zoom controls