### PR TITLE
download map bug fix

### DIFF
--- a/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
+++ b/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
@@ -78,7 +78,7 @@ class LeafletChoroplethMap:
             children=[
                 dl.TileLayer() if self.show_tile_layer else None,
                 self._get_colorbar(),
-                self._get_colorbar_title(),
+                self._get_colorbar_title(self.enable_zoom),
                 self._get_dl_geojson(),
             ],
             center=[54.5, -2.5],  # Centered on the UK
@@ -264,10 +264,10 @@ class LeafletChoroplethMap:
             tickText=tick_text,  # Optional, makes labels look cleaner
         )
 
-    def _get_colorbar_title(self):
+    def _get_colorbar_title(self, enable_zoom: bool=False):
         if self.color_scale_is_discrete:
             return None
-        top = "70px" if self.enable_zoom is False else "140px"
+        top = "70px" if enable_zoom is False else "140px"
         return html.Div(
             self.hover_text_columns[0],
             style={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="22.1.0",
+    version="22.2.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
Fix bug when downloading map with regards to colour bar title - always default zoom controls to False when downloading map