### PR TITLE
Map tab bug - fix: TypeError: window.dash_leaflet.getMap is not a function

### DIFF
--- a/gov_uk_dashboards/assets/register_maps
+++ b/gov_uk_dashboards/assets/register_maps
@@ -1,0 +1,15 @@
+if (!window.pageMaps) window.pageMaps = {};
+
+function tryRegisterMaps() {
+    document.querySelectorAll(".leaflet-container").forEach(el => {
+        if (el.id && !window.pageMaps[el.id]) {
+            const mapInstance = el._leaflet_map || el._leaflet;
+            if (mapInstance) {
+                window.pageMaps[el.id] = mapInstance;
+                console.log("Registered Leaflet map:", el.id);
+            }
+        }
+    });
+}
+
+setInterval(tryRegisterMaps, 500);

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Department for Levelling Up, Housing and Communities",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="25.5.0",
+    version="25.5.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint gov_uk_dashboards` locally
- [ ] Run `python -u -m pytest --headless tests` locally
- [ ] Include screenshot for any visual changes
- [ ] Incremented the version in `setup.py`

### PR Description:
