### PR TITLE
Hide colourbar title small screens

### DIFF
--- a/gov_uk_dashboards/assets/dashboard.css
+++ b/gov_uk_dashboards/assets/dashboard.css
@@ -9560,3 +9560,8 @@ mark.expenditure {
     display: none;
   }
 }
+@media (max-width: 1300px) {
+  .colorbar-title {
+    display: none;
+  }
+}

--- a/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
+++ b/gov_uk_dashboards/components/leaflet/leaflet_choropleth_map.py
@@ -537,6 +537,7 @@ class LeafletChoroplethMap:
             top = "70px" if enable_zoom is False else "140px"
             return html.Div(
                 self.colorbar_title,
+                className="colorbar-title",
                 style={
                     "position": "absolute",
                     "top": top,  # Adjusted to place above the colorbar

--- a/scss/dashboard.scss
+++ b/scss/dashboard.scss
@@ -1695,3 +1695,10 @@ mark.expenditure {
     display: none
   }
 }
+
+// Hide colourbar title when width < 1300px
+@media (max-width: 1300px) {
+  .colorbar-title {
+    display: none;
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Ministry of Housing, Communities & Local Government",
     description="Provides access to functionality common to creating a data dashboard.",
     name="gov_uk_dashboards",
-    version="31.9.0",
+    version="31.10.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [x] Run `pylint gov_uk_dashboards` locally
- [x] Run `python -u -m pytest --headless tests` locally
- [N/A] Include screenshot for any visual changes
- [x] Incremented the version in `setup.py`

### PR Description:

- Hide map colourbar title on small screens